### PR TITLE
Fix: sync mcp extra for tools/graphify-al (missed from #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ git -C data/docs-devitpro sparse-checkout init --cone && git -C data/docs-devitp
 
 # 1. Build each subproject's venv
 uv sync --project tools/cocoindex-code
-uv sync --project tools/graphify-al --extra al
+uv sync --project tools/graphify-al --extra al --extra mcp
 uv sync --project chunker
 uv sync --project aggregator
 uv sync --project registry

--- a/registry/uv.lock
+++ b/registry/uv.lock
@@ -271,6 +271,7 @@ requires-dist = [
     { name = "tiktoken", marker = "extra == 'kimi'" },
     { name = "tiktoken", marker = "extra == 'openai'" },
     { name = "tree-sitter", specifier = ">=0.23.0,<0.26" },
+    { name = "tree-sitter-al", marker = "extra == 'al'", specifier = ">=3.0.1" },
     { name = "tree-sitter-bash", specifier = ">=0.23,<0.27" },
     { name = "tree-sitter-c", specifier = ">=0.23,<0.25" },
     { name = "tree-sitter-c-sharp", specifier = ">=0.23,<0.25" },
@@ -307,7 +308,7 @@ requires-dist = [
     { name = "yt-dlp", marker = "extra == 'all'", specifier = ">=2026.6.9" },
     { name = "yt-dlp", marker = "extra == 'video'", specifier = ">=2026.6.9" },
 ]
-provides-extras = ["mcp", "neo4j", "falkordb", "pdf", "watch", "svg", "leiden", "office", "google", "postgres", "video", "kimi", "ollama", "bedrock", "anthropic", "gemini", "openai", "chinese", "sql", "dm", "terraform", "all"]
+provides-extras = ["al", "mcp", "neo4j", "falkordb", "pdf", "watch", "svg", "leiden", "office", "google", "postgres", "video", "kimi", "ollama", "bedrock", "anthropic", "gemini", "openai", "chinese", "sql", "dm", "terraform", "all"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/scripts/deploy-vm.sh
+++ b/scripts/deploy-vm.sh
@@ -17,11 +17,13 @@ echo "==> uv sync (all subprojects)"
 for p in tools/cocoindex-code chunker aggregator registry build; do
   uv sync --project "$p"
 done
-# tools/graphify-al's AL support (tree-sitter-al) is an optional extra
-# there (graphify is multi-language, AL is opt-in) but not optional for
-# this project -- always sync it in. chunker's own tree-sitter-al pin is
-# already a hard dependency in chunker/pyproject.toml, no extra needed.
-uv sync --project tools/graphify-al --extra al
+# tools/graphify-al's AL support (tree-sitter-al) and MCP HTTP transport
+# (uvicorn/starlette) are both optional extras there (graphify is
+# multi-language and multi-transport by default) but neither is optional
+# for this project -- always sync both in. chunker's own tree-sitter-al
+# pin is already a hard dependency in chunker/pyproject.toml, no extra
+# needed there.
+uv sync --project tools/graphify-al --extra al --extra mcp
 
 echo "==> restart services"
 sudo systemctl restart bcatlas.target


### PR DESCRIPTION
PR #1's merge dropped the last commit that added `--extra mcp` to the graphify-al sync (a race between me pushing it and merging #1 -- the merge API call apparently used the PR's slightly-earlier state). Cherry-picks that commit. Confirmed live on the bc-atlas VM: without this, `bcatlas-graph.service` crash-loops with `ModuleNotFoundError: uvicorn`.