### PR TITLE
Fix deploy-vm.sh: uv not on PATH under forced-command SSH

### DIFF
--- a/scripts/deploy-vm.sh
+++ b/scripts/deploy-vm.sh
@@ -8,6 +8,13 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
+# The forced-command SSH session this runs under (see the CD deploy key's
+# authorized_keys entry) isn't a login shell, so ~/.local/bin (where uv
+# installs) isn't on PATH by default -- confirmed live, the first real CD
+# run failed with "uv: command not found". uv's own installer-generated env
+# script adds it idempotently.
+[ -f "$HOME/.local/bin/env" ] && . "$HOME/.local/bin/env"
+
 echo "==> git pull"
 git fetch --quiet origin master
 git reset --hard origin/master


### PR DESCRIPTION
Confirmed against two real failed Deploy runs on the bc-atlas VM: the forced-command SSH session the CD key runs under isn't a login shell, so ~/.local/bin (where uv installs) was never on PATH. Sources uv's own installer env script instead.