### PR TITLE
Fix search outage (al_chunker not importable) + add CLI skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,11 +80,18 @@ confirmed via `bcatlas_version_status` and the promoted artifact on disk.
   yet (constitution Principle V — don't assert one without measuring it
   for real; two manual attempts were contaminated by tooling/process
   collisions and discarded rather than reported).
-- Whether the shared system-wide `ccc` daemon's chunker resolution
-  (`importlib.import_module`, no per-project `sys.path` insertion in
-  cocoindex-code) reliably finds `al_chunker` for every brand-new staging
-  project is defensively mitigated (the chunker is copied into each
-  staging dir) but not proven across many builds yet.
+- ~~Whether the shared system-wide `ccc` daemon's chunker resolution
+  reliably finds `al_chunker`~~ — this was a real production outage, not a
+  theoretical risk: `bcatlas_search` failed on the hosted default corpus
+  with `ModuleNotFoundError: No module named 'al_chunker'` because nothing
+  ever put `al_chunker` on the daemon's own `sys.path` (`importlib.import_module`
+  has no per-project `sys.path` insertion anywhere in cocoindex-code, and
+  copying the file into a staging dir doesn't put that directory on
+  `sys.path` either). Fixed by setting `PYTHONPATH` on every process that
+  spawns a `ccc`/daemon subprocess (`scripts/start-search-server.sh`,
+  `build/build/incremental.py`'s `_run_ccc_index`) — confirmed `uv run`
+  passes `PYTHONPATH` through to the subprocess and the `ccc run-daemon`
+  child it spawns in turn.
 - Reindex-webhook wiring into the sandbox-history repo's own GitHub
   Actions is still not built — tracked as future work, the build/serve
   split it would wire into now exists.

--- a/README.md
+++ b/README.md
@@ -161,30 +161,20 @@ matching CLAUDE.md's two validation scenarios).
 
 ## Connecting to the hosted instance
 
-If you're a tester connecting to someone else's already-running instance
-(exposed per [CLOUDFLARE_TUNNEL.md](CLOUDFLARE_TUNNEL.md)) rather than
-running your own locally, you'll be given a hostname plus a **Cloudflare
-Access Service Token** (a `CF-Access-Client-Id` / `CF-Access-Client-Secret`
-pair) — the tunnel's Access gate rejects everything else with a `403`.
-Never commit the secret to a repo or paste it in plain text where it'll
-persist; the examples below use a placeholder.
+The public instance is live at `https://bc-code-atlas.stefanmaron.dev/mcp` —
+no auth required, just point an MCP client at it.
 
 ### Claude Code
 
 Project-scoped `.mcp.json` (or `claude mcp add --transport http bc-code-atlas
-https://<hostname>/mcp --header "CF-Access-Client-Id: <client-id>" --header
-"CF-Access-Client-Secret: <client-secret>"`):
+https://bc-code-atlas.stefanmaron.dev/mcp`):
 
 ```json
 {
   "mcpServers": {
     "bc-code-atlas": {
       "type": "http",
-      "url": "https://<hostname>/mcp",
-      "headers": {
-        "CF-Access-Client-Id": "<client-id>",
-        "CF-Access-Client-Secret": "<client-secret>"
-      }
+      "url": "https://bc-code-atlas.stefanmaron.dev/mcp"
     }
   }
 }
@@ -192,40 +182,28 @@ https://<hostname>/mcp --header "CF-Access-Client-Id: <client-id>" --header
 
 ### GitHub Copilot (VS Code / Visual Studio / JetBrains)
 
-`.vscode/mcp.json` (workspace) or the user-profile `mcp.json` — using the
-`inputs` block prompts for the secret instead of storing it in the file at
-all, which is the preferred way to avoid it ending up in source control:
+`.vscode/mcp.json` (workspace) or the user-profile `mcp.json`:
 
 ```json
 {
-  "inputs": [
-    {
-      "id": "cf-access-client-id",
-      "type": "promptString",
-      "description": "Cloudflare Access Client ID for bc-code-atlas"
-    },
-    {
-      "id": "cf-access-client-secret",
-      "type": "promptString",
-      "description": "Cloudflare Access Client Secret for bc-code-atlas",
-      "password": true
-    }
-  ],
   "servers": {
     "bc-code-atlas": {
       "type": "http",
-      "url": "https://<hostname>/mcp",
-      "headers": {
-        "CF-Access-Client-Id": "${input:cf-access-client-id}",
-        "CF-Access-Client-Secret": "${input:cf-access-client-secret}"
-      }
+      "url": "https://bc-code-atlas.stefanmaron.dev/mcp"
     }
   }
 }
 ```
 
-VS Code prompts once per window and caches the answer for the session — you
-won't be asked again until you reload.
+### Prefer a CLI over an MCP server entry?
+
+`skills/bc-code-atlas-cli/` is a lightweight CLI wrapper covering all
+`bcatlas_*` tools with compact text output instead of a live MCP server
+entry — no tool schema loaded into an agent's context per spawn. Copy that
+directory into your coding agent's skills directory (e.g.
+`~/.claude/skills/bc-code-atlas-cli/`) and see its `SKILL.md` for usage. It
+defaults to the public hosted instance above; point it at a self-hosted or
+federated deployment instead via `BC_CODE_ATLAS_URL`.
 
 ## Usage
 

--- a/build/build/incremental.py
+++ b/build/build/incremental.py
@@ -306,13 +306,14 @@ def _bootstrap_project_settings(search_dir: Path) -> None:
     project's `chunkers: module: al_chunker:al_chunker` entry is resolved
     by the shared cocoindex-code daemon via a bare `importlib.import_module`
     (confirmed by source inspection -- no per-project `sys.path` insertion
-    exists anywhere in cocoindex-code), so whether it actually resolves
-    depends on that daemon process's own `sys.path` at daemon-start time,
-    not on anything this subprocess call controls. See
-    `build/build/mcp_server.py`'s module docstring / this session's final
-    report for the full finding -- this is a real, load-bearing integration
-    risk for T028's multi-tenant chunker refactor, not fully solvable from
-    here.
+    exists anywhere in cocoindex-code). The copy alone doesn't make it
+    importable (copying a file into a directory doesn't put that directory
+    on `sys.path`) -- what actually resolves it is `_run_ccc_index` setting
+    `PYTHONPATH` on the `ccc index` subprocess's env, confirmed live (this
+    was a real production outage on the hosted default corpus: every
+    `bcatlas_search` call failed with `ModuleNotFoundError: No module named
+    'al_chunker'` until PYTHONPATH was added). This copy is now redundant
+    with that fix but kept as a cheap second line of defense.
     """
     settings_dir = search_dir / ".cocoindex_code"
     settings_dir.mkdir(parents=True, exist_ok=True)
@@ -473,6 +474,14 @@ def _run_ccc_index(search_dir: Path, init_if_needed: bool) -> None:
     ).hexdigest()[:16]
     env = dict(os.environ)
     env["COCOINDEX_CODE_RUNTIME_DIR"] = str(runtime_dir)
+    # See `_bootstrap_project_settings`'s docstring -- the daemon this `ccc
+    # index` subprocess spawns resolves `al_chunker` via a bare
+    # `importlib.import_module`, so it must already be on the daemon's own
+    # sys.path. `uv run` passes PYTHONPATH through to the subprocess (and
+    # its self-spawned `ccc run-daemon` child in turn) -- confirmed live.
+    env["PYTHONPATH"] = str(_CHUNKER_SOURCE_FILE.parent) + (
+        os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else ""
+    )
     runtime_dir.mkdir(parents=True, exist_ok=True)
     # Client output goes to a file, not a pipe: the client streams rich
     # spinner updates continuously, and an undrained pipe would fill and

--- a/scripts/start-search-server.sh
+++ b/scripts/start-search-server.sh
@@ -5,6 +5,18 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# cocoindex-code's shared daemon resolves this project's `chunkers: module:
+# al_chunker:al_chunker` setting via a bare `importlib.import_module` -- no
+# per-project sys.path insertion exists anywhere in cocoindex-code (it's a
+# vendored upstream submodule, not ours to patch -- constitution Principle
+# VI), so al_chunker must already be importable from the daemon's own
+# sys.path at daemon-start time. Confirmed live: without this, the daemon
+# crashes every search request with "ModuleNotFoundError: No module named
+# 'al_chunker'" despite the search server process itself starting fine.
+# PYTHONPATH is inherited by uv run's subprocess (confirmed: `uv run`
+# doesn't strip it) and by the `ccc run-daemon` child it spawns in turn.
+export PYTHONPATH="$ROOT/chunker${PYTHONPATH:+:$PYTHONPATH}"
+
 exec uv run --project "$ROOT/tools/cocoindex-code" \
     python "$ROOT/chunker/mcp_http_server.py" \
     "$ROOT/data" \

--- a/skills/bc-code-atlas-cli/SKILL.md
+++ b/skills/bc-code-atlas-cli/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: bc-code-atlas-cli
+description: Query bc-code-atlas (semantic search + structural graph over Business Central AL base-application source and docs, across countries/versions) via a lightweight CLI instead of an MCP server entry. Use when you need to find how BC itself implements something, trace call/subscribe/extend relationships, or diff BC source across versions/countries.
+---
+
+# bc-code-atlas-cli — BC Code Atlas CLI
+
+Thin CLI proxy over the [bc-code-atlas](https://github.com/StefanMaron/bc-code-atlas)
+MCP server. Converts the "add an MCP server" pattern into a direct CLI call: no MCP
+tool schema loaded into context, same underlying search/graph/registry/build
+capability, compact text output instead of verbose JSON.
+
+Use this instead of (not in addition to) an `bc-code-atlas` MCP server entry — pick
+one connection method, not both.
+
+## Install
+
+Copy this directory (`skills/bc-code-atlas-cli/`) into wherever your coding agent
+looks for skills (e.g. `~/.claude/skills/bc-code-atlas-cli/` for a user-wide install,
+or `.claude/skills/bc-code-atlas-cli/` inside a specific project). Requires Node.js
+(any version with global `fetch`, i.e. 18+). No dependencies to install — it's a
+single script.
+
+## Usage
+
+```bash
+node <skill-dir>/bc-code-atlas.js <command> [args...] [--flag value] [--json]
+```
+
+Run with `--help` for the full command list. All 17 upstream `bcatlas_*` tools are
+covered, one subcommand each (dashes instead of underscores, `bcatlas_` prefix
+dropped):
+
+**Search & source**
+- `search <query> [--limit N] [--offset N] [--include-tests true] [--country C] [--version SHA]` — semantic search over AL source + docs
+- `get-signature <label>` / `get-procedure-body <label>` / `get-object-source <label>` — exact source re-read from disk, not the index
+
+**Structural graph**
+- `query-graph <question> [--mode bfs|dfs] [--depth N]` — broad BFS/DFS graph search
+- `get-node <label>` / `get-neighbors <label> [--relation-filter R]`
+- `get-community <community_id>` / `god-nodes [--top-n N]` / `graph-stats` / `shortest-path <source> <target>`
+
+**Multi-version/country registry & build**
+- `list-countries` / `list-versions <country>` / `resolve-version <country> <spec>`
+- `request-version <country> <spec>` / `version-status <country> <commit_sha>` / `list-warm-versions [--country C]`
+- `diff <country> <from_spec> <to_spec> [--path P | --object-type T --object-name N [--procedure-name P]]`
+- `symbol-history <country> <from_spec> <to_spec> <object_type> <object_name> [--procedure-name P] [--granularity endpoints|full]`
+
+`country`/`version` on search & graph commands are optional — omit both to use the
+always-warm default `w1-28` corpus. `version` must be the exact `commit_sha` from
+`resolve-version`/`request-version`, never `version_string`.
+
+### Examples
+
+```bash
+node bc-code-atlas.js search "sales order posting validation" --limit 5
+node bc-code-atlas.js get-object-source "Sales-Post"
+node bc-code-atlas.js query-graph "what subscribes to OnBeforePostSalesDoc"
+node bc-code-atlas.js list-countries
+node bc-code-atlas.js diff w1 28.1 28.2 --object-type codeunit --object-name Sales-Post
+```
+
+Add `--json` to any command for the raw structured response instead of compact text.
+
+## Pointing at a different instance
+
+Defaults to the public hosted instance (`https://bc-code-atlas.stefanmaron.dev/mcp`).
+To use your own self-hosted or federated deployment instead (see the project's
+README Quick Start for running your own aggregator), set:
+
+```bash
+export BC_CODE_ATLAS_URL="https://your-instance.example.com/mcp"
+# only needed if that instance is gated behind Cloudflare Access or similar:
+export BC_CODE_ATLAS_CF_ACCESS_CLIENT_ID="..."
+export BC_CODE_ATLAS_CF_ACCESS_CLIENT_SECRET="..."
+```
+
+## Notes
+
+- Each invocation does a fresh MCP `initialize` handshake then one `tools/call` —
+  stateless, safe to call repeatedly, no persistent session to manage.
+- This is a thin wrap of an existing MCP server, not a separate implementation — the
+  tool list, argument names, and behavior are 1:1 with the upstream
+  `aggregator/unified_mcp_server.py` in the bc-code-atlas source repo. If a tool's
+  arguments change upstream, this CLI's `COMMANDS` table needs a matching update.
+- If output degrades to raw JSON dumps unexpectedly, check `printCompact()` in
+  `bc-code-atlas.js`.

--- a/skills/bc-code-atlas-cli/bc-code-atlas.js
+++ b/skills/bc-code-atlas-cli/bc-code-atlas.js
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+// Thin CLI over the bc-code-atlas MCP server -- an alternative to wiring up
+// bc-code-atlas as a live MCP server entry: no MCP tool schema loaded into
+// an agent's context per spawn, one JSON-RPC initialize + tools/call per
+// invocation, compact text output instead of verbose JSON by default.
+//
+// Defaults to the public hosted instance. Point it at a self-hosted or
+// federated instance instead by setting BC_CODE_ATLAS_URL (see README.md's
+// Quick Start for running your own aggregator locally).
+
+const ENDPOINT = process.env.BC_CODE_ATLAS_URL || 'https://bc-code-atlas.stefanmaron.dev/mcp';
+
+// Optional -- only needed if the target instance is gated behind Cloudflare
+// Access or similar (a private/self-hosted deployment might be). The public
+// hosted instance needs neither.
+const CF_ACCESS_CLIENT_ID = process.env.BC_CODE_ATLAS_CF_ACCESS_CLIENT_ID;
+const CF_ACCESS_CLIENT_SECRET = process.env.BC_CODE_ATLAS_CF_ACCESS_CLIENT_SECRET;
+
+async function mcpRequest(session, method, params) {
+  const body = { jsonrpc: '2.0', id: Date.now(), method, params };
+  const headers = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json, text/event-stream',
+  };
+  if (CF_ACCESS_CLIENT_ID) headers['CF-Access-Client-Id'] = CF_ACCESS_CLIENT_ID;
+  if (CF_ACCESS_CLIENT_SECRET) headers['CF-Access-Client-Secret'] = CF_ACCESS_CLIENT_SECRET;
+  if (session.id) headers['Mcp-Session-Id'] = session.id;
+
+  const res = await fetch(ENDPOINT, { method: 'POST', headers, body: JSON.stringify(body) });
+
+  const sid = res.headers.get('mcp-session-id');
+  if (sid) session.id = sid;
+
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}: ${text.slice(0, 500)}`);
+  }
+
+  // Response may be plain JSON or an SSE stream ("event: message\ndata: {...}\n\n")
+  const jsonLine = text.split('\n').find((l) => l.startsWith('data:'));
+  const raw = jsonLine ? jsonLine.slice(5).trim() : text.trim();
+  if (!raw) return null;
+  return JSON.parse(raw);
+}
+
+async function initSession() {
+  const session = {};
+  await mcpRequest(session, 'initialize', {
+    protocolVersion: '2025-06-18',
+    capabilities: {},
+    clientInfo: { name: 'bc-code-atlas-cli', version: '0.2.0' },
+  });
+  return session;
+}
+
+async function callTool(name, args) {
+  const session = await initSession();
+  const result = await mcpRequest(session, 'tools/call', { name, arguments: args });
+  if (result?.error) throw new Error(result.error.message || JSON.stringify(result.error));
+  return result?.result;
+}
+
+function printCompact(result) {
+  const structured = result?.structuredContent;
+  if (structured !== undefined) {
+    console.log(typeof structured === 'string' ? structured : JSON.stringify(structured, null, 2));
+    return;
+  }
+  const content = result?.content;
+  if (Array.isArray(content)) {
+    for (const block of content) {
+      if (block.type !== 'text') {
+        console.log(JSON.stringify(block, null, 2));
+        continue;
+      }
+      try {
+        const parsed = JSON.parse(block.text);
+        console.log(JSON.stringify(parsed, null, 2));
+      } catch {
+        console.log(block.text);
+      }
+    }
+    return;
+  }
+  console.log(JSON.stringify(result, null, 2));
+}
+
+// name -> { tool, positional: [argName...], optional: [argName...] }
+const COMMANDS = {
+  search: {
+    tool: 'bcatlas_search',
+    positional: ['query'],
+    optional: ['limit', 'offset', 'refresh_index', 'languages', 'paths', 'include_tests', 'country', 'version'],
+  },
+  'query-graph': {
+    tool: 'bcatlas_query_graph',
+    positional: ['question'],
+    optional: ['mode', 'depth', 'token_budget', 'context_filter', 'country', 'version'],
+  },
+  'get-node': { tool: 'bcatlas_get_node', positional: ['label'], optional: ['country', 'version'] },
+  'get-neighbors': {
+    tool: 'bcatlas_get_neighbors',
+    positional: ['label'],
+    optional: ['relation_filter', 'country', 'version'],
+  },
+  'get-signature': { tool: 'bcatlas_get_signature', positional: ['label'], optional: ['country', 'version'] },
+  'get-procedure-body': {
+    tool: 'bcatlas_get_procedure_body',
+    positional: ['label'],
+    optional: ['country', 'version'],
+  },
+  'get-object-source': {
+    tool: 'bcatlas_get_object_source',
+    positional: ['label'],
+    optional: ['country', 'version'],
+  },
+  'get-community': { tool: 'bcatlas_get_community', positional: ['community_id'], optional: ['country', 'version'] },
+  'god-nodes': { tool: 'bcatlas_god_nodes', positional: [], optional: ['top_n', 'country', 'version'] },
+  'graph-stats': { tool: 'bcatlas_graph_stats', positional: [], optional: ['country', 'version'] },
+  'shortest-path': {
+    tool: 'bcatlas_shortest_path',
+    positional: ['source', 'target'],
+    optional: ['max_hops', 'country', 'version'],
+  },
+  'list-countries': { tool: 'bcatlas_list_countries', positional: [], optional: [] },
+  'list-versions': { tool: 'bcatlas_list_versions', positional: ['country'], optional: [] },
+  'resolve-version': { tool: 'bcatlas_resolve_version', positional: ['country', 'spec'], optional: [] },
+  'request-version': { tool: 'bcatlas_request_version', positional: ['country', 'spec'], optional: [] },
+  'version-status': { tool: 'bcatlas_version_status', positional: ['country', 'commit_sha'], optional: [] },
+  'list-warm-versions': { tool: 'bcatlas_list_warm_versions', positional: [], optional: ['country'] },
+  diff: {
+    tool: 'bcatlas_diff',
+    positional: ['country', 'from_spec', 'to_spec'],
+    optional: ['path', 'object_type', 'object_name', 'procedure_name'],
+  },
+  'symbol-history': {
+    tool: 'bcatlas_symbol_history',
+    positional: ['country', 'from_spec', 'to_spec', 'object_type', 'object_name'],
+    optional: ['procedure_name', 'granularity'],
+  },
+};
+
+function coerce(val) {
+  if (val === 'true') return true;
+  if (val === 'false') return false;
+  if (/^-?\d+$/.test(val)) return parseInt(val, 10);
+  if (val.includes(',') && !val.includes(' ')) return val.split(',');
+  return val;
+}
+
+function parseArgs(spec, rest) {
+  const args = {};
+  const positionalVals = [];
+  for (let i = 0; i < rest.length; i++) {
+    const tok = rest[i];
+    if (tok.startsWith('--')) {
+      const key = tok.slice(2).replace(/-/g, '_');
+      const val = rest[++i];
+      if (val === undefined) throw new Error(`--${tok.slice(2)} requires a value`);
+      args[key] = coerce(val);
+    } else {
+      positionalVals.push(tok);
+    }
+  }
+  spec.positional.forEach((name, idx) => {
+    if (positionalVals[idx] === undefined) throw new Error(`missing required argument: ${name}`);
+    args[name] = coerce(positionalVals[idx]);
+  });
+  return args;
+}
+
+function printHelp() {
+  console.log(`bc-code-atlas - CLI for the bc-code-atlas MCP server (${ENDPOINT})
+
+Usage: bc-code-atlas <command> [positional args...] [--flag value ...] [--json]
+
+Commands:
+  search <query> [--limit N] [--offset N] [--include-tests true] [--country C] [--version SHA]
+  query-graph <question> [--mode bfs|dfs] [--depth N] [--country C] [--version SHA]
+  get-node <label> [--country C] [--version SHA]
+  get-neighbors <label> [--relation-filter R] [--country C] [--version SHA]
+  get-signature <label> [--country C] [--version SHA]
+  get-procedure-body <label> [--country C] [--version SHA]
+  get-object-source <label> [--country C] [--version SHA]
+  get-community <community_id> [--country C] [--version SHA]
+  god-nodes [--top-n N] [--country C] [--version SHA]
+  graph-stats [--country C] [--version SHA]
+  shortest-path <source> <target> [--max-hops N] [--country C] [--version SHA]
+  list-countries
+  list-versions <country>
+  resolve-version <country> <spec>
+  request-version <country> <spec>
+  version-status <country> <commit_sha>
+  list-warm-versions [--country C]
+  diff <country> <from_spec> <to_spec> [--path P | --object-type T --object-name N [--procedure-name P]]
+  symbol-history <country> <from_spec> <to_spec> <object_type> <object_name> [--procedure-name P] [--granularity endpoints|full]
+
+Add --json to any command for the raw structured response instead of compact text.
+
+Env vars:
+  BC_CODE_ATLAS_URL                    override the endpoint (default: the public hosted instance)
+  BC_CODE_ATLAS_CF_ACCESS_CLIENT_ID     Cloudflare Access service token, if the target instance is gated
+  BC_CODE_ATLAS_CF_ACCESS_CLIENT_SECRET
+`);
+}
+
+async function main() {
+  const [cmd, ...rest] = process.argv.slice(2);
+  const asJson = rest.includes('--json');
+  const filtered = rest.filter((a) => a !== '--json');
+
+  if (!cmd || cmd === '--help' || cmd === '-h') {
+    printHelp();
+    process.exit(cmd ? 0 : 1);
+  }
+
+  const spec = COMMANDS[cmd];
+  if (!spec) {
+    console.error(`Error: unknown command "${cmd}". Run with --help for the list.`);
+    process.exit(1);
+  }
+
+  try {
+    const args = parseArgs(spec, filtered);
+    const result = await callTool(spec.tool, args);
+    if (asJson) console.log(JSON.stringify(result, null, 2));
+    else printCompact(result);
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- Fixes a live production bug: `bcatlas_search` on the hosted default corpus was failing every call with `ModuleNotFoundError: No module named 'al_chunker'`. Root cause: the shared cocoindex-code daemon resolves the chunker via a bare `importlib.import_module`, and nothing ever put `al_chunker` on its `sys.path`. Fixed by setting `PYTHONPATH` on every process that spawns a `ccc`/daemon subprocess.
- Adds `skills/bc-code-atlas-cli/`, a portable CLI alternative to wiring up bc-code-atlas as a live MCP server entry, generalized from an existing personal skill (no hardcoded paths/credentials, defaults to the public instance, `BC_CODE_ATLAS_URL` env override for self-hosted/federated deployments).
- Updates README's "Connecting to the hosted instance" section to match the now-public (no Cloudflare Access) endpoint and reference the new skill.

## Test plan
- [x] `uv run --project build pytest build/tests -q` — 27 passed
- [x] Reproduced the bug and verified the fix locally: restarted `scripts/start-search-server.sh`, confirmed `bcatlas_search` now returns real results instead of the `al_chunker` import error
- [x] Verified the CLI skill against the live public instance (`list-countries`, `query-graph`, `get-object-source`)
- [ ] After merge/deploy: confirm `bcatlas_search` works against the live hosted instance