### PR TITLE
Fix search: al_chunker's own deps (tree-sitter) weren't importable either

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,17 +81,21 @@ confirmed via `bcatlas_version_status` and the promoted artifact on disk.
   for real; two manual attempts were contaminated by tooling/process
   collisions and discarded rather than reported).
 - ~~Whether the shared system-wide `ccc` daemon's chunker resolution
-  reliably finds `al_chunker`~~ — this was a real production outage, not a
-  theoretical risk: `bcatlas_search` failed on the hosted default corpus
-  with `ModuleNotFoundError: No module named 'al_chunker'` because nothing
-  ever put `al_chunker` on the daemon's own `sys.path` (`importlib.import_module`
-  has no per-project `sys.path` insertion anywhere in cocoindex-code, and
-  copying the file into a staging dir doesn't put that directory on
-  `sys.path` either). Fixed by setting `PYTHONPATH` on every process that
-  spawns a `ccc`/daemon subprocess (`scripts/start-search-server.sh`,
-  `build/build/incremental.py`'s `_run_ccc_index`) — confirmed `uv run`
-  passes `PYTHONPATH` through to the subprocess and the `ccc run-daemon`
-  child it spawns in turn.
+  reliably finds `al_chunker`~~ — this was a real, two-part production
+  outage, not a theoretical risk: `bcatlas_search` failed on the hosted
+  default corpus, first with `ModuleNotFoundError: No module named
+  'al_chunker'`, then (after a first PYTHONPATH-only fix that solved that
+  half) with `... 'tree_sitter'` (al_chunker's own real dependency).
+  `importlib.import_module` has no per-project `sys.path` insertion
+  anywhere in cocoindex-code, and copying the file into a staging dir
+  doesn't put that directory on `sys.path` either. Properly fixed by
+  passing `--with-editable <chunker dir>` to every `uv run` that spawns a
+  `ccc`/daemon subprocess (`scripts/start-search-server.sh`,
+  `build/build/incremental.py`'s `_run_ccc_index`) — builds an ephemeral
+  overlay venv merging cocoindex-code's own locked deps with chunker/'s
+  (bc-al-chunker) real ones, which the daemon these subprocesses spawn
+  inherits too (it locates its own `ccc` executable via
+  `Path(sys.executable).parent`).
 - Reindex-webhook wiring into the sandbox-history repo's own GitHub
   Actions is still not built — tracked as future work, the build/serve
   split it would wire into now exists.

--- a/build/build/incremental.py
+++ b/build/build/incremental.py
@@ -302,18 +302,23 @@ def _bootstrap_project_settings(search_dir: Path) -> None:
     shelling out to `ccc init` -- `ccc init` only ever writes
     cocoindex-code's generic, language-agnostic default settings, which
     would silently produce an AL-empty index. Also copies `al_chunker.py`
-    into the staging search dir itself as a defensive measure: this
+    into the staging search dir itself as a defensive measure -- this
     project's `chunkers: module: al_chunker:al_chunker` entry is resolved
     by the shared cocoindex-code daemon via a bare `importlib.import_module`
     (confirmed by source inspection -- no per-project `sys.path` insertion
-    exists anywhere in cocoindex-code). The copy alone doesn't make it
-    importable (copying a file into a directory doesn't put that directory
-    on `sys.path`) -- what actually resolves it is `_run_ccc_index` setting
-    `PYTHONPATH` on the `ccc index` subprocess's env, confirmed live (this
-    was a real production outage on the hosted default corpus: every
-    `bcatlas_search` call failed with `ModuleNotFoundError: No module named
-    'al_chunker'` until PYTHONPATH was added). This copy is now redundant
-    with that fix but kept as a cheap second line of defense.
+    exists anywhere in cocoindex-code, and the copy alone doesn't fix that:
+    copying a file into a directory doesn't put that directory on
+    `sys.path`). This was a real, two-part production outage on the hosted
+    default corpus (every `bcatlas_search` call failed, first with
+    `ModuleNotFoundError: No module named 'al_chunker'`, then -- after
+    fixing that half -- `... 'tree_sitter'`, al_chunker's own real
+    dependency) before `_run_ccc_index` started passing `--with-editable
+    <chunker dir>` to `uv run`: that builds an ephemeral overlay venv
+    merging cocoindex-code's own locked deps with chunker/'s (bc-al-chunker)
+    real ones, which the daemon this subprocess spawns inherits too (it
+    locates its own `ccc` executable via `Path(sys.executable).parent`).
+    This copy is now redundant with that fix but kept as a cheap second
+    line of defense.
     """
     settings_dir = search_dir / ".cocoindex_code"
     settings_dir.mkdir(parents=True, exist_ok=True)
@@ -474,14 +479,6 @@ def _run_ccc_index(search_dir: Path, init_if_needed: bool) -> None:
     ).hexdigest()[:16]
     env = dict(os.environ)
     env["COCOINDEX_CODE_RUNTIME_DIR"] = str(runtime_dir)
-    # See `_bootstrap_project_settings`'s docstring -- the daemon this `ccc
-    # index` subprocess spawns resolves `al_chunker` via a bare
-    # `importlib.import_module`, so it must already be on the daemon's own
-    # sys.path. `uv run` passes PYTHONPATH through to the subprocess (and
-    # its self-spawned `ccc run-daemon` child in turn) -- confirmed live.
-    env["PYTHONPATH"] = str(_CHUNKER_SOURCE_FILE.parent) + (
-        os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else ""
-    )
     runtime_dir.mkdir(parents=True, exist_ok=True)
     # Client output goes to a file, not a pipe: the client streams rich
     # spinner updates continuously, and an undrained pipe would fill and
@@ -497,7 +494,16 @@ def _run_ccc_index(search_dir: Path, init_if_needed: bool) -> None:
             attempt_start_fp = _index_state_fingerprint(search_dir)
             with open(client_log, "ab") as log_fd:
                 proc = subprocess.Popen(
-                    ["uv", "run", "--project", str(_COCOINDEX_PROJECT), "ccc", "index"],
+                    [
+                        "uv",
+                        "run",
+                        "--project",
+                        str(_COCOINDEX_PROJECT),
+                        "--with-editable",
+                        str(_CHUNKER_SOURCE_FILE.parent),
+                        "ccc",
+                        "index",
+                    ],
                     cwd=search_dir,
                     env=env,
                     stdout=log_fd,

--- a/scripts/start-search-server.sh
+++ b/scripts/start-search-server.sh
@@ -9,15 +9,23 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # al_chunker:al_chunker` setting via a bare `importlib.import_module` -- no
 # per-project sys.path insertion exists anywhere in cocoindex-code (it's a
 # vendored upstream submodule, not ours to patch -- constitution Principle
-# VI), so al_chunker must already be importable from the daemon's own
-# sys.path at daemon-start time. Confirmed live: without this, the daemon
-# crashes every search request with "ModuleNotFoundError: No module named
-# 'al_chunker'" despite the search server process itself starting fine.
-# PYTHONPATH is inherited by uv run's subprocess (confirmed: `uv run`
-# doesn't strip it) and by the `ccc run-daemon` child it spawns in turn.
-export PYTHONPATH="$ROOT/chunker${PYTHONPATH:+:$PYTHONPATH}"
-
-exec uv run --project "$ROOT/tools/cocoindex-code" \
+# VI), so al_chunker (and its own real deps, tree-sitter/tree-sitter-al)
+# must already be importable from the daemon's own environment at
+# daemon-start time. Confirmed live: without this, the daemon crashes every
+# search request with "ModuleNotFoundError" (first for al_chunker itself,
+# then -- after a PYTHONPATH-only fix that solved that half but not the
+# other -- for tree_sitter) despite the search server process itself
+# starting fine. `--with-editable` builds an ephemeral overlay venv merging
+# cocoindex-code's own locked deps with chunker/'s (bc-al-chunker) real
+# ones and runs this command through it; the `ccc run-daemon` child this
+# process spawns in turn locates its own `ccc` executable via
+# `Path(sys.executable).parent` (cocoindex_code/client.py), which resolves
+# to that same overlay venv, so the daemon inherits it too -- confirmed
+# live. Deliberately not a plain `uv pip install` into the venv: that would
+# get silently pruned back out by the next `uv sync --project
+# tools/cocoindex-code` (every deploy runs one) since it's not a locked
+# dependency of the vendored project.
+exec uv run --project "$ROOT/tools/cocoindex-code" --with-editable "$ROOT/chunker" \
     python "$ROOT/chunker/mcp_http_server.py" \
     "$ROOT/data" \
     --host "${SEARCH_HOST:-127.0.0.1}" \


### PR DESCRIPTION
## Summary
Follow-up to #4, which fixed `al_chunker` itself but not its own dependency (`tree_sitter`). After #4 deployed, live search still failed:

```
Query failed: Daemon error: No module named 'tree_sitter'
```

`cocoindex-code` (vendored upstream) doesn't declare `tree-sitter` as a dependency at all -- it was only ever importable locally by accident of a stale dev venv that never got pruned, never reproducible on a clean deploy.

Switched from PYTHONPATH to `uv run --with-editable <chunker dir>`, which installs `al_chunker` AND its real deps (tree-sitter, tree-sitter-al) into an ephemeral overlay venv in one mechanism, inherited by the daemon subprocess these commands spawn.

## Test plan
- [x] `uv run --project build pytest build/tests -q` -- 27 passed
- [x] Verified locally end-to-end: restarted the search server with this fix, ran a real search through the local aggregator, got real results instead of an import error
- [ ] After merge/deploy: confirm `bcatlas_search` works against the live hosted instance