### PR TITLE
Fix search: HF Hub etag round trips tripped the stall watchdog

### DIFF
--- a/build/build/incremental.py
+++ b/build/build/incremental.py
@@ -479,6 +479,14 @@ def _run_ccc_index(search_dir: Path, init_if_needed: bool) -> None:
     ).hexdigest()[:16]
     env = dict(os.environ)
     env["COCOINDEX_CODE_RUNTIME_DIR"] = str(runtime_dir)
+    # See `scripts/start-search-server.sh` -- the embedding model is already
+    # fully cached locally, but without this the daemon still does dozens
+    # of etag-freshness round trips to huggingface.co on every cold start
+    # before loading from cache, which on the hosted VM took over 90s and
+    # tripped the search server's stall watchdog (unrelated to this
+    # subprocess directly, but the same daemon code path, so the same real
+    # fix applies here too).
+    env["HF_HUB_OFFLINE"] = "1"
     runtime_dir.mkdir(parents=True, exist_ok=True)
     # Client output goes to a file, not a pipe: the client streams rich
     # spinner updates continuously, and an undrained pipe would fill and

--- a/scripts/start-search-server.sh
+++ b/scripts/start-search-server.sh
@@ -5,6 +5,19 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# The embedding model is already fully cached locally after first download,
+# but sentence-transformers/huggingface_hub still does dozens of sequential
+# HEAD/GET etag-freshness round trips to huggingface.co on every daemon
+# cold start (confirmed live) before loading from cache -- on the hosted
+# VM this alone took over 90s, tripping mcp_http_server.py's on-disk-
+# progress stall watchdog (which reasonably treats a search/query call as
+# stalled if nothing's been written under `.cocoindex_code/` for 90s: model
+# loading writes nothing there, so it always looked stalled to that
+# watchdog) and killing the daemon before it ever finished loading -- a
+# search-always-fails loop on every restart. HF_HUB_OFFLINE skips those
+# round trips entirely; confirmed live this cuts model load to ~8s.
+export HF_HUB_OFFLINE=1
+
 # cocoindex-code's shared daemon resolves this project's `chunkers: module:
 # al_chunker:al_chunker` setting via a bare `importlib.import_module` -- no
 # per-project sys.path insertion exists anywhere in cocoindex-code (it's a


### PR DESCRIPTION
## Summary
Follow-up to #4/#5. After those deployed, live search still failed with:

```
cocoindex daemon stalled 3 time(s) in a row on '/opt/bc-code-atlas/data' with no on-disk progress for 90s each time -- giving up.
```

Root cause, confirmed via the VM's daemon.log: the embedding model is fully cached locally, but `sentence-transformers`/`huggingface_hub` still does dozens of etag-freshness round trips to huggingface.co on every daemon cold start before loading from cache. That took well over 90s on the VM, tripping the stall watchdog (which measures on-disk writes -- model loading writes nothing there) and killing the daemon before it ever finished -- a search-always-fails loop on every restart.

`HF_HUB_OFFLINE=1` skips those round trips. Confirmed live on the VM with a direct benchmark: model load dropped from >90s to 7.6s.

## Test plan
- [x] `uv run --project build pytest build/tests -q` -- 27 passed
- [x] Benchmarked directly on the VM: model load 7.6s with `HF_HUB_OFFLINE=1` vs. previously observed >90s without it
- [ ] After merge/deploy: confirm `bcatlas_search` works against the live hosted instance