### PR TITLE
Fix search's infinite restart loop: full corpus reindex on every daemon start

### DIFF
--- a/chunker/mcp_http_server.py
+++ b/chunker/mcp_http_server.py
@@ -104,6 +104,15 @@ def _is_test_path(file_path: str) -> bool:
 # rationale as the build side), duplicated rather than cross-imported
 # because this project deliberately has no dependency on `build/` (see the
 # module docstring's multi-tenant routing note above).
+#
+# A second, distinct cause of what looked like the same "stall" was found
+# and fixed live (this session): a fresh daemon's first index of this
+# corpus is a genuine ~30+ minute full reprocess (see `_progress_signal`'s
+# docstring), during which the on-disk fingerprint this watchdog used to
+# check stayed completely flat -- so the watchdog was killing a perfectly
+# healthy, progressing reindex every `_STALL_TIMEOUT_S`, forever, before it
+# could ever finish. `_progress_signal` now also polls the daemon's live
+# IndexingProgress counters so this case reads as forward progress instead.
 _STALL_TIMEOUT_S = 90.0
 _STALL_POLL_INTERVAL_S = 5.0
 _MAX_STALL_RETRIES = 3
@@ -135,6 +144,51 @@ def _index_state_fingerprint(project_root: str) -> tuple[int, float]:
         total += st.st_size
         newest = max(newest, st.st_mtime)
     return (total, newest)
+
+
+def _progress_signal(project_root: str) -> tuple[int, float, tuple[int, ...]]:
+    """Extends `_index_state_fingerprint` with the daemon's own live
+    `IndexingProgress` counters, fetched via a fresh `project_status()`
+    round trip -- confirmed live (this session) that a fresh daemon's
+    *first* index of this corpus is a genuine, unavoidable full reprocess
+    that runs 30+ minutes with the on-disk fingerprint completely flat the
+    whole time (`chunker/chunking.py`'s `CHUNKER_REGISTRY` docstring: custom
+    chunker callables aren't fingerprint-able, so cocoindex-code cannot
+    memoize across a daemon restart and reprocesses every file from
+    scratch -- confirmed by tracing `cocoindex/_internal/memo_fingerprint.py`
+    -- upstream-by-design, Principle VI, not something to patch). Disk
+    writes apparently only flush in an infrequent/late batch during that
+    pass, so the disk-only signal alone reads a genuinely healthy,
+    progressing reindex as a stall and kills the daemon before it can ever
+    finish -- an unrecoverable restart loop. `project_status()` opens its
+    own independent connection (`client._send` -> `_connect_and_handshake`
+    every call) and `daemon.py` dispatches each connection as its own
+    asyncio task with a lock-free `get_status()` read, so it stays
+    responsive even while an `index()`/`search()` call is in flight on a
+    different connection -- verified by reading `daemon.py`'s
+    `ProjectStatusRequest` handling. Best-effort: if the daemon is busy
+    enough that even this fails or times out oddly, fall back to the disk
+    signal alone rather than raising out of a progress check.
+    """
+    disk_total, disk_mtime = _index_state_fingerprint(project_root)
+    counters: tuple[int, ...] = ()
+    try:
+        from cocoindex_code import client as _client
+
+        status = _client.project_status(project_root)
+        if status.progress is not None:
+            p = status.progress
+            counters = (
+                p.num_execution_starts,
+                p.num_unchanged,
+                p.num_adds,
+                p.num_deletes,
+                p.num_reprocesses,
+                p.num_errors,
+            )
+    except Exception:
+        pass
+    return (disk_total, disk_mtime, counters)
 
 
 def _kill_shared_daemon_hard() -> None:
@@ -196,9 +250,11 @@ def _run_with_stall_recovery(fn: Callable[[], _T], project_root: str) -> _T:
     of hanging forever.
 
     `fn` runs on a background thread (there is no way to cancel a thread
-    blocked in `Connection.recv_bytes()`) while this polls the on-disk
-    index fingerprint. No change for `_STALL_TIMEOUT_S` means a genuine
-    stall -- kill the daemon (which unblocks the stuck thread with a
+    blocked in `Connection.recv_bytes()`) while this polls `_progress_signal`
+    (on-disk index fingerprint plus the daemon's own live IndexingProgress
+    counters -- see that function's docstring for why disk state alone
+    isn't a reliable signal here). No change for `_STALL_TIMEOUT_S` means a
+    genuine stall -- kill the daemon (which unblocks the stuck thread with a
     `RuntimeError`, since `index()`/`search()` both turn `EOFError` on the
     now-closed socket into one) and retry with a fresh daemon. Resuming is
     cheap and lossless: verified live (this session) that `ccc index`
@@ -217,13 +273,13 @@ def _run_with_stall_recovery(fn: Callable[[], _T], project_root: str) -> _T:
         thread = threading.Thread(target=_target, daemon=True)
         thread.start()
 
-        last_fp = _index_state_fingerprint(project_root)
+        last_fp = _progress_signal(project_root)
         last_progress = time.monotonic()
         while thread.is_alive():
             thread.join(timeout=_STALL_POLL_INTERVAL_S)
             if not thread.is_alive():
                 break
-            fp = _index_state_fingerprint(project_root)
+            fp = _progress_signal(project_root)
             now = time.monotonic()
             if fp != last_fp:
                 last_fp = fp

--- a/scripts/deploy-vm.sh
+++ b/scripts/deploy-vm.sh
@@ -44,6 +44,15 @@ main() {
   echo "==> restart services"
   sudo systemctl restart bcatlas.target
 
+  # A fresh daemon's first search pays a genuine ~30+ minute full corpus
+  # reprocess, unconditionally, by design -- see
+  # scripts/wait-for-search-ready.py's module docstring. Waiting for it here
+  # (instead of letting the first live user pay it, and letting "deploy
+  # complete" below lie about actual readiness) is the whole point of this
+  # step.
+  echo "==> waiting for search index to warm up"
+  python3 "$ROOT/scripts/wait-for-search-ready.py"
+
   echo "==> deploy complete: $(git rev-parse --short HEAD)"
 }
 

--- a/scripts/wait-for-search-ready.py
+++ b/scripts/wait-for-search-ready.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Block until the local search backend has finished warming up after a
+(re)start, and fail loudly if it never does.
+
+Why this exists: `chunker/chunking.py`'s `CHUNKER_REGISTRY` docstring
+documents (and this session traced and confirmed via
+`cocoindex/_internal/memo_fingerprint.py`) that cocoindex-code cannot
+memoize its custom AL chunker across a daemon restart -- every fresh
+daemon (i.e. every deploy, since `deploy-vm.sh` restarts `bcatlas.target`)
+pays a genuine ~30+ minute full reprocess of the whole corpus on its
+*first* search/index call, upstream-by-design (constitution Principle VI,
+not something to patch). Without this wait, `deploy-vm.sh` used to report
+"deploy complete" the instant `systemctl restart` returned, while real
+user queries hitting the still-cold daemon paid that cost inline (and,
+before a companion fix in `mcp_http_server.py`, could get caught in an
+watchdog restart loop that never finished at all). This makes that cost
+visible in the deploy log instead of silently landing on the first live
+user after every deploy.
+
+Issues one real `bcatlas_search` call against the local chunker server
+(not the aggregator, to avoid coupling this wait to any other backend's
+own startup) and blocks until it succeeds -- the same call path, and the
+same `refresh_index=True` default, that a real MCP client would use.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+SEARCH_URL = "http://127.0.0.1:8801/mcp"
+# Generous: this call's own request can legitimately take 30-60+ minutes
+# on a cold daemon (see module docstring). Connection-refused retries
+# (server process still starting) use a much shorter budget below.
+REQUEST_TIMEOUT_S = 3600.0
+CONNECT_RETRY_TIMEOUT_S = 120.0
+CONNECT_RETRY_INTERVAL_S = 2.0
+
+
+def _mcp_post(session: dict, method: str, params: dict) -> dict | None:
+    body = json.dumps({"jsonrpc": "2.0", "id": int(time.time() * 1000), "method": method, "params": params}).encode()
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    if session.get("id"):
+        headers["Mcp-Session-Id"] = session["id"]
+    req = urllib.request.Request(SEARCH_URL, data=body, headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_S) as resp:
+        sid = resp.headers.get("Mcp-Session-Id")
+        if sid:
+            session["id"] = sid
+        text = resp.read().decode()
+    line = next((l for l in text.split("\n") if l.startswith("data:")), None)
+    raw = line[5:].strip() if line else text.strip()
+    return json.loads(raw) if raw else None
+
+
+def _wait_for_port() -> None:
+    deadline = time.monotonic() + CONNECT_RETRY_TIMEOUT_S
+    while True:
+        try:
+            urllib.request.urlopen(urllib.request.Request(SEARCH_URL, method="GET"), timeout=5)
+            return
+        except urllib.error.HTTPError:
+            return  # server is up and rejecting GET -- that's fine, it's alive
+        except (urllib.error.URLError, ConnectionError, TimeoutError):
+            if time.monotonic() >= deadline:
+                raise RuntimeError(
+                    f"search server never came up on {SEARCH_URL} within "
+                    f"{CONNECT_RETRY_TIMEOUT_S:.0f}s of the service restart"
+                ) from None
+            time.sleep(CONNECT_RETRY_INTERVAL_S)
+
+
+def main() -> int:
+    print(f"waiting for {SEARCH_URL} to accept connections...", flush=True)
+    _wait_for_port()
+
+    print(
+        "search server is up -- issuing a warm-up search (may take 30+ minutes on a "
+        "fresh daemon, see chunker/chunking.py's CHUNKER_REGISTRY comment)...",
+        flush=True,
+    )
+    start = time.monotonic()
+    session: dict = {}
+    _mcp_post(
+        session,
+        "initialize",
+        {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "wait-for-search-ready", "version": "1.0.0"},
+        },
+    )
+    result = _mcp_post(
+        session,
+        "tools/call",
+        {"name": "bcatlas_search", "arguments": {"query": "deploy warm-up", "limit": 1}},
+    )
+    elapsed = time.monotonic() - start
+
+    if result is None or result.get("error"):
+        err = result.get("error") if result else "no response"
+        print(f"warm-up search FAILED after {elapsed:.0f}s: {err}", file=sys.stderr, flush=True)
+        return 1
+
+    structured = (result.get("result") or {}).get("structuredContent")
+    if isinstance(structured, dict) and structured.get("success") is False:
+        print(
+            f"warm-up search FAILED after {elapsed:.0f}s: {structured.get('message')}",
+            file=sys.stderr,
+            flush=True,
+        )
+        return 1
+
+    print(f"search index is warm -- ready in {elapsed:.0f}s", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Root-caused the ongoing production search outage: cocoindex-code cannot memoize its custom AL chunker across a daemon restart (documented in `chunker/chunking.py`'s `CHUNKER_REGISTRY` comment, confirmed by tracing `cocoindex/_internal/memo_fingerprint.py`), so every fresh daemon pays a genuine 30+ minute full corpus reprocess, by design.
- That full reindex writes nothing to disk for most of its duration, which was exactly what the existing stall watchdog in `chunker/mcp_http_server.py` used to detect a stall — so it was killing a perfectly healthy reindex every ~4.5 minutes, forever, before it could finish. Fixed by also polling the daemon's own live `IndexingProgress` counters via `project_status()`.
- Since the 30+ minute cost itself is real and can't be eliminated (Principle VI — not patching vendored `cocoindex-code`), `scripts/deploy-vm.sh` now issues a real warm-up search after every restart (`scripts/wait-for-search-ready.py`) and waits for it before reporting "deploy complete", so the cost is visible in the deploy log instead of landing on the first live user.

## Test plan
- [x] `uv run --project build pytest build/tests -q` — 27 passed
- [x] `python3 -m py_compile` on both modified/new Python files
- [x] `bash -n scripts/deploy-vm.sh`
- [ ] Live re-verify against the public instance post-deploy: confirm a search survives an actual daemon restart end-to-end (not just once by luck)

https://claude.ai/code/session_01R7vy16Y6VeWmDXQKSxBMGv