### PR TITLE
Keep the search daemon warm across routine deploys instead of restarting it

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,14 @@ jobs:
     # Only deploy when the CI run this was triggered by actually succeeded --
     # a push to master whose CI failed must never reach the public service.
     if: github.event.workflow_run.conclusion == 'success'
+    # Default (360min) worst case is uncomfortably close to a genuine
+    # cold-start search warm-up (scripts/wait-for-search-ready.py): a clean
+    # live measurement showed one pass running well past 2 hours, and
+    # mcp_http_server.py's stall watchdog can retry that up to 3x before
+    # giving up. Explicit headroom above that theoretical worst case --
+    # this should rarely if ever actually be needed now that the search
+    # daemon survives routine deploys (scripts/systemd/bcatlas-search.service.d).
+    timeout-minutes: 480
     steps:
       - name: Deploy over SSH
         run: |

--- a/scripts/deploy-vm.sh
+++ b/scripts/deploy-vm.sh
@@ -24,6 +24,11 @@ cd "$ROOT"
 # block up front, before executing any of it, so it's immune to the
 # underlying file changing after parsing.
 main() {
+  # Captured before `git reset --hard` moves HEAD, so we can tell below
+  # whether this deploy actually touched the search daemon's own code.
+  local old_head
+  old_head="$(git rev-parse HEAD)"
+
   echo "==> git pull"
   git fetch --quiet origin master
   git reset --hard origin/master
@@ -41,15 +46,46 @@ main() {
   # needed there.
   uv sync --project tools/graphify-al --extra al --extra mcp
 
+  # Idempotent: keeps /etc/systemd/system/bcatlas-search.service.d/'s
+  # KillMode=process override in sync with the tracked copy (see that
+  # file's own comment for the full why). daemon-reload is a no-op if
+  # nothing changed.
+  echo "==> sync systemd overrides"
+  sudo mkdir -p /etc/systemd/system/bcatlas-search.service.d
+  sudo cp "$ROOT/scripts/systemd/bcatlas-search.service.d/override.conf" \
+    /etc/systemd/system/bcatlas-search.service.d/override.conf
+  sudo systemctl daemon-reload
+
+  # With KillMode=process in effect, `systemctl restart bcatlas.target`
+  # below no longer kills the search daemon (`ccc run-daemon`) -- it
+  # survives and keeps serving from its already-warm state, which is the
+  # whole point (see the override's own comment). But that also means a
+  # code change to al_chunker or cocoindex-code itself wouldn't take
+  # effect until the daemon actually restarts -- so when this deploy
+  # touched either, explicitly kill the daemon's whole cgroup first
+  # (bypassing the override for this one intentional case via
+  # `--kill-whom=all`) so the restart below picks up the new code instead
+  # of silently continuing to serve with the old daemon.
+  if ! git diff --quiet "$old_head" HEAD -- chunker/ tools/cocoindex-code; then
+    echo "==> chunker/cocoindex-code changed -- killing the search daemon so it picks up the new code"
+    sudo systemctl kill --kill-whom=all --signal=SIGTERM bcatlas-search.service || true
+    sleep 2
+    sudo systemctl kill --kill-whom=all --signal=SIGKILL bcatlas-search.service || true
+  fi
+
   echo "==> restart services"
   sudo systemctl restart bcatlas.target
 
-  # A fresh daemon's first search pays a genuine ~30+ minute full corpus
-  # reprocess, unconditionally, by design -- see
-  # scripts/wait-for-search-ready.py's module docstring. Waiting for it here
-  # (instead of letting the first live user pay it, and letting "deploy
-  # complete" below lie about actual readiness) is the whole point of this
-  # step.
+  # Usually near-instant now (the daemon survived the restart above and is
+  # already warm). Only pays a real cost on a genuine cold start: first
+  # deploy after this change, a VM reboot, a crash, or the explicit kill
+  # just above -- a fresh daemon's first search pays a genuine, unavoidable
+  # full corpus reprocess (see chunker/chunking.py's CHUNKER_REGISTRY
+  # comment) that ran well past 2 hours in a clean live measurement this
+  # session on this VM's CPU-only hardware, not the ~30 minutes originally
+  # estimated. Waiting for it here either way (instead of letting the
+  # first live user pay it, and letting "deploy complete" below lie about
+  # actual readiness) is the whole point of this step.
   echo "==> waiting for search index to warm up"
   python3 "$ROOT/scripts/wait-for-search-ready.py"
 

--- a/scripts/systemd/bcatlas-search.service.d/override.conf
+++ b/scripts/systemd/bcatlas-search.service.d/override.conf
@@ -1,0 +1,30 @@
+# Installed by deploy-vm.sh into /etc/systemd/system/bcatlas-search.service.d/
+# on the serving VM (that unit file itself isn't tracked here -- it predates
+# this override and was provisioned manually; this drop-in only overrides one
+# setting on top of it without needing to duplicate the whole unit).
+#
+# Why: bcatlas-search.service's own process (`start-search-server.sh` ->
+# mcp_http_server.py) spawns cocoindex-code's `ccc run-daemon` as a genuine,
+# deliberately detached child (`start_new_session=True`, its own session
+# leader -- see chunker/mcp_http_server.py's `_kill_shared_daemon_hard`
+# docstring) so its lifecycle doesn't follow its spawning parent's. But
+# session detachment doesn't escape the systemd *cgroup* the daemon still
+# inherits, and systemd's default KillMode=control-group kills every process
+# in a unit's cgroup on stop/restart regardless of session/process-group --
+# confirmed live (this session) via `systemctl show -p KillMode,ExecMainPID`
+# and watching the daemon's PID change on every `systemctl restart
+# bcatlas.target`, which deploy-vm.sh runs on *every* deploy, even ones
+# touching nothing search-related.
+#
+# That daemon restart is expensive, not free: cocoindex-code can't
+# memoize its custom AL chunker across a fresh daemon process (see
+# chunker/chunking.py's CHUNKER_REGISTRY comment), so every fresh daemon
+# pays a genuine full corpus reprocess -- confirmed live this session to run
+# well past 2 hours on this VM's CPU-only hardware. KillMode=process scopes
+# systemd's automatic stop/restart kill to just the main tracked process,
+# letting the daemon survive routine deploys and keep serving from its
+# already-warm state -- turning that multi-hour cost from "every deploy"
+# into "only on a genuine cold start" (VM reboot, crash, or an explicit kill
+# deploy-vm.sh issues when chunker/cocoindex-code code itself changed).
+[Service]
+KillMode=process

--- a/scripts/wait-for-search-ready.py
+++ b/scripts/wait-for-search-ready.py
@@ -5,17 +5,23 @@
 Why this exists: `chunker/chunking.py`'s `CHUNKER_REGISTRY` docstring
 documents (and this session traced and confirmed via
 `cocoindex/_internal/memo_fingerprint.py`) that cocoindex-code cannot
-memoize its custom AL chunker across a daemon restart -- every fresh
-daemon (i.e. every deploy, since `deploy-vm.sh` restarts `bcatlas.target`)
-pays a genuine ~30+ minute full reprocess of the whole corpus on its
+memoize its custom AL chunker across a daemon restart -- a fresh daemon
+pays a genuine, unavoidable full reprocess of the whole corpus on its
 *first* search/index call, upstream-by-design (constitution Principle VI,
-not something to patch). Without this wait, `deploy-vm.sh` used to report
-"deploy complete" the instant `systemctl restart` returned, while real
-user queries hitting the still-cold daemon paid that cost inline (and,
-before a companion fix in `mcp_http_server.py`, could get caught in an
-watchdog restart loop that never finished at all). This makes that cost
-visible in the deploy log instead of silently landing on the first live
-user after every deploy.
+not something to patch). A clean live measurement this session showed this
+running well past 2 hours on this VM's CPU-only hardware -- much longer
+than the ~30 minutes first assumed. `scripts/systemd/bcatlas-search.service.d/override.conf`
+(installed by `deploy-vm.sh`) now keeps the daemon warm across *routine*
+deploys, so this should mostly only be paid on a genuine cold start (VM
+reboot, crash, or an explicit kill `deploy-vm.sh` issues when
+chunker/cocoindex-code code itself changed) rather than on every deploy.
+Without this wait, `deploy-vm.sh` used to report "deploy complete" the
+instant `systemctl restart` returned, while real user queries hitting a
+still-cold daemon paid that cost inline (and, before a companion fix in
+`mcp_http_server.py`, could get caught in a watchdog restart loop that
+never finished at all). This makes that cost visible in the deploy log
+instead of silently landing on the first live user after a cold-start
+deploy.
 
 Issues one real `bcatlas_search` call against the local chunker server
 (not the aggregator, to avoid coupling this wait to any other backend's
@@ -32,10 +38,13 @@ import urllib.error
 import urllib.request
 
 SEARCH_URL = "http://127.0.0.1:8801/mcp"
-# Generous: this call's own request can legitimately take 30-60+ minutes
-# on a cold daemon (see module docstring). Connection-refused retries
-# (server process still starting) use a much shorter budget below.
-REQUEST_TIMEOUT_S = 3600.0
+# Generous: this call's own request can legitimately take 2+ hours on a
+# cold daemon (see module docstring), and mcp_http_server.py's own stall
+# watchdog can retry that up to 3x on a genuine stall before giving up --
+# so this must comfortably exceed that worst case, not just one pass.
+# Connection-refused retries (server process still starting) use a much
+# shorter budget below.
+REQUEST_TIMEOUT_S = 4.0 * 3600.0
 CONNECT_RETRY_TIMEOUT_S = 120.0
 CONNECT_RETRY_INTERVAL_S = 2.0
 
@@ -81,8 +90,9 @@ def main() -> int:
     _wait_for_port()
 
     print(
-        "search server is up -- issuing a warm-up search (may take 30+ minutes on a "
-        "fresh daemon, see chunker/chunking.py's CHUNKER_REGISTRY comment)...",
+        "search server is up -- issuing a warm-up search (may take 2+ hours on a "
+        "genuinely cold daemon, see chunker/chunking.py's CHUNKER_REGISTRY comment; "
+        "near-instant if the daemon survived from a prior deploy)...",
         flush=True,
     )
     start = time.monotonic()


### PR DESCRIPTION
## Summary
- Live testing of PR #7's fix surfaced that the underlying cost is much bigger than assumed: a clean measurement ran the daemon's first-ever index past 2 hours on the VM's CPU-only hardware (not ~30 minutes). Paying that on every deploy, including unrelated ones, isn't sustainable.
- Root cause: `bcatlas-search.service`'s default `KillMode=control-group` kills the detached `ccc run-daemon` subprocess on every `systemctl restart bcatlas.target`, which `deploy-vm.sh` runs on every push to master regardless of what changed.
- `scripts/systemd/bcatlas-search.service.d/override.conf` sets `KillMode=process` so the daemon survives routine restarts and keeps serving from its already-warm state. `deploy-vm.sh` installs this drop-in and only explicitly kills the daemon (via `systemctl kill --kill-whom=all`) when a deploy actually touches `chunker/` or `tools/cocoindex-code`, so real code changes there still take effect.
- Corrected `wait-for-search-ready.py`'s timeout/docs and gave the deploy job explicit `timeout-minutes: 480` headroom, since the theoretical worst case (one 2+ hour cold pass, retried up to 3x by the stall watchdog) is no longer safely inside GitHub's 360-minute default.

## Test plan
- [x] `uv run --project build pytest build/tests -q` — 27 passed
- [x] `bash -n scripts/deploy-vm.sh`, `python3 -m py_compile scripts/wait-for-search-ready.py`, YAML parse check on `deploy.yml`
- [x] Live-confirmed the underlying `KillMode=control-group` cause via `systemctl show -p KillMode,ExecMainPID` on the VM and watching the daemon PID change across restarts
- [ ] Live re-verify: next deploy should install the drop-in and, on the deploy *after* that, the daemon should survive and the warm-up wait should return near-instantly

https://claude.ai/code/session_01R7vy16Y6VeWmDXQKSxBMGv