### PR TITLE
Add CI guard for search daemon restart persistence (constitution Principle VIII)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,3 +104,40 @@ jobs:
       # about coverage a full import would need the real venv for.
       - name: chunker parses cleanly
         run: python3 -c "import ast; ast.parse(open('chunker/al_chunker.py').read()); ast.parse(open('chunker/mcp_http_server.py').read())"
+
+  search-daemon-persistence:
+    name: search daemon survives a restart without reprocessing (constitution Principle VIII)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      # Only tools/cocoindex-code is needed here -- this job exercises the
+      # real daemon/CLI machinery + the real al_chunker plugin, not the
+      # multi-GB data/ corpora.
+      - name: Init tools/cocoindex-code submodule
+        run: git submodule update --init tools/cocoindex-code
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+
+      # A routine deploy restarts the shared search daemon (systemd
+      # `KillMode=control-group`) -- constitution Principle VIII requires
+      # that restart to resume from on-disk state rather than reprocess the
+      # whole corpus from zero, or the ~30min build SLA this service exists
+      # for stops being meaningful (a deploy could silently trigger a
+      # multi-hour reindex). This test spins up the real daemon via
+      # `--with-editable chunker` (same overlay-venv wiring
+      # scripts/start-search-server.sh uses in production), indexes a real
+      # tiny AL corpus with the real al_chunker plugin, kills and respawns
+      # the daemon, and asserts the pre-restart files come back as
+      # `num_unchanged`, not reprocessed. If a future cocoindex-code bump,
+      # storage-layout change, or path-mapping change breaks resumption,
+      # this fails and blocks the merge.
+      - name: Run daemon persistence-across-restart test
+        run: |
+          uv run --project tools/cocoindex-code --with-editable chunker \
+            pytest chunker/tests/test_daemon_persistence.py -v

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,10 +1,10 @@
 <!--
 Sync Impact Report
-- Version change: (none, template) → 1.0.0
-- Modified principles: n/a (first ratification)
-- Added sections: all (Core Principles I-VII, Technology & Data Constraints,
-  Development Workflow, Governance)
-- Removed sections: template placeholders only
+- Version change: 1.0.0 → 1.1.0
+- Modified principles: n/a
+- Added sections: Core Principle VIII (Deploys Must Not Reset the Serving
+  Index)
+- Removed sections: none
 - Templates requiring updates:
   - .specify/templates/plan-template.md ⚠ pending — its "Constitution Check"
     gate is generic; when the first real plan is generated, populate it with
@@ -19,8 +19,9 @@ Sync Impact Report
     needs a full rewrite in a follow-up step, not part of this amendment.
   - README.md ⚠ pending — "This is a proof of concept" framing and the
     single-version Quick Start are now stale; follow-up step.
-- Follow-up TODOs: none deferred — all placeholders resolved from the
-  session's architecture conclusions and repo history.
+- Follow-up TODOs: none deferred — Principle VIII's claim was directly
+  verified against the deployed code (not assumed) before being ratified;
+  see the principle's Rationale for the exact code paths checked.
 -->
 
 # bc-code-atlas Constitution
@@ -151,6 +152,51 @@ every caller compounds across the whole community, and a misleading tool
 description wastes calls at scale in a way a single local user would never
 notice.
 
+### VIII. Deploys Must Not Reset the Serving Index
+
+The shared search daemon's cold-start reindex (hours, not minutes — see
+"Key facts already established" in `CLAUDE.md`) MUST NEVER be an implicit
+side effect of a routine code deploy. A deploy is only permitted to restart
+the search-serving process when: (a) the process resumes from its existing
+on-disk state rather than reprocessing everything from zero, and (b) that
+resumption has been verified against the actual deployed code, not assumed.
+If a future change to `cocoindex-code`, its storage layout, or the deploy
+path (env var overrides, path mappings, container/ephemeral-disk moves)
+would break resumption, that change MUST NOT ship until an equivalent
+persistence guarantee is restored — deploys are otherwise something that
+happens constantly while operating this service (bug fixes, unrelated
+features), and an accidental full reset on every one of them makes the
+hosted VM approach itself infeasible, not just slow.
+
+**Rationale**: directly verified by reading the deployed
+`cocoindex-code` code (commit `7fe0e89`, identical on the VM and in this
+repo at the time of verification) rather than inferred from one lucky
+restart: `Project.create()`
+(`tools/cocoindex-code/src/cocoindex_code/project.py`) opens
+`cocoindex.db` (incremental-state tracking) and `target_sqlite.db` (vector
+index) at a deterministic, disk-backed path
+(`resolve_db_dir()`/`settings.py`, `project_root/.cocoindex_code/` with no
+env override configured on the VM) using `mkdir(..., exist_ok=True)` — it
+never creates fresh/empty stores on process start. `self._app.update()` is
+cocoindex's own content-hash-based incremental engine: it diffs current
+file content against what is already recorded in those persisted stores,
+so files already indexed by a now-dead process come back as
+`num_unchanged` (skipped) rather than being reprocessed. Live-measured
+confirmation: after a routine `systemctl restart` on the hosted VM,
+`num_unchanged` was already >10,000 immediately, not 0. This makes the
+earlier working assumption baked into `chunker/chunking.py`'s
+`CHUNKER_REGISTRY` comment and repeated through `CLAUDE.md` ("a fresh
+daemon process cannot trust ANY prior state") obsolete and due for
+correction there — that assumption was true of a *different* project root
+per (country, version) build artifact (each of those genuinely has no
+prior state the first time it's built), not of the one shared,
+long-lived, single-path serving daemon this principle is about. The one
+residual, not-yet-stress-tested risk: this reasoning assumes the on-disk
+LMDB/SQLite state survives an *ungraceful* kill (e.g. the stall watchdog's
+SIGKILL path) without corruption — both formats are designed to be
+crash-safe, but that specific scenario hasn't been directly reproduced and
+verified, only reasoned about from format guarantees.
+
 ## Technology & Data Constraints
 
 - **Source of truth**: `StefanMaron/MSDyn365BC.Sandbox.Code.History` — one
@@ -221,4 +267,4 @@ the proposed design against the Core Principles above, with any violation
 explicitly justified in that plan's Complexity Tracking section rather than
 silently accepted.
 
-**Version**: 1.0.0 | **Ratified**: 2026-07-02 | **Last Amended**: 2026-07-02
+**Version**: 1.1.0 | **Ratified**: 2026-07-02 | **Last Amended**: 2026-08-03

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,16 +150,33 @@ here since they're not principles, just measurements:
   slower than either the original ~30min estimate or the "well past 2
   hours" figure from earlier this session, and this is now measured with
   real IndexingProgress counters, not inferred from DB file size: ~39% of
-  ~24,300 files done after ~6 hours on the hosted VM's 4-vCPU hardware, in
-  a clean, single-daemon, non-thrashing run. This is a genuine, different
-  problem from the build-side one above (build reuses a warm sibling's
-  already-indexed `.cocoindex_code/` state; a fresh daemon process cannot
-  trust ANY prior state at all, warm or not — `chunker/chunking.py`'s
-  `CHUNKER_REGISTRY` comment). Don't assume this number is stable across
-  VM/corpus changes — re-measure via `project_status()`'s live counters
-  (`num_unchanged + num_reprocesses` vs. `total_files`) rather than
-  inferring from `target_sqlite.db`'s byte size, which was observed live
-  to plateau for very long stretches during genuine, healthy compute.
+  ~24,300 files done after ~6 hours, then ~55% after ~14 hours (a second
+  independent sample), on the hosted VM's 4-vCPU hardware. Don't assume
+  this number is stable across VM/corpus changes — re-measure via
+  `project_status()`'s live counters (`num_unchanged + num_reprocesses` vs.
+  `total_files`) rather than inferring from `target_sqlite.db`'s byte size,
+  which was observed live to plateau for very long stretches during
+  genuine, healthy compute.
+  **Correction (2026-08-03), see constitution Principle VIII**: the
+  earlier claim here that "a fresh daemon process cannot trust ANY prior
+  state at all" was wrong for this always-warm shared serving daemon
+  specifically (it remains true of a brand-new per-(country, version)
+  build artifact's *first* build, which genuinely has no prior state).
+  Verified directly against the deployed `cocoindex-code` source
+  (`tools/cocoindex-code/src/cocoindex_code/project.py`'s `Project.create`
+  + `resolve_db_dir()`/`settings.py`): the daemon's `.cocoindex_code/`
+  state (`cocoindex.db`, `target_sqlite.db`) lives at a deterministic,
+  disk-backed path that a fresh process reopens rather than recreates, and
+  `self._app.update()` is a content-hash-based incremental engine that
+  skips already-indexed files as `num_unchanged`. Live-confirmed: a
+  routine `systemctl restart` on the VM resumed with `num_unchanged` already
+  >10,000, not 0. **This means routine deploys do NOT have to cost a full
+  cold reindex** — the daemon survives a restart cheaply as long as its
+  on-disk `.cocoindex_code/` state isn't wiped and the project_root path
+  stays the same. The one open risk, not yet stress-tested: whether this
+  holds under an *ungraceful* kill (the stall watchdog's SIGKILL path),
+  vs. only the graceful SIGTERM restart path actually observed live so
+  far.
 - Cross-country content overlap is much higher than git ancestry suggests:
   `w1-28` vs `us-28` share ~87% byte-identical `.al` files at the same
   path (10,962 of 12,604 in `us-28`) despite the two branches having no

--- a/chunker/tests/test_daemon_persistence.py
+++ b/chunker/tests/test_daemon_persistence.py
@@ -1,0 +1,163 @@
+"""Regression guard for constitution Principle VIII (Deploys Must Not Reset
+the Serving Index): the search daemon must resume from its on-disk state
+after a process restart, not reprocess an already-indexed corpus from
+scratch.
+
+Uses the real `al_chunker` registration path and a real (small)
+sentence-transformers model against real cocoindex-code daemon/CLI
+machinery -- no mocking of the mechanism under test (constitution
+Principle V). If a future change to cocoindex-code, its storage layout, or
+`.cocoindex_code/` path resolution breaks resumption, this test fails and
+blocks the merge -- exactly the guard Principle VIII requires.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from cocoindex_code import client
+from cocoindex_code.cli import app
+from cocoindex_code.client import stop_daemon
+from cocoindex_code.protocol import IndexingProgress
+from cocoindex_code.settings import (
+    ChunkerMapping,
+    EmbeddingSettings,
+    ProjectSettings,
+    UserSettings,
+    save_project_settings,
+    save_user_settings,
+)
+
+runner = CliRunner()
+
+# Same small, fast model cocoindex-code's own test suite uses -- a real
+# download and a real embed, just cheap enough for CI (constitution
+# Principle V: don't mock what can be measured for real).
+TEST_EMBEDDING_MODEL = "sentence-transformers/paraphrase-MiniLM-L3-v2"
+
+SAMPLE_CODEUNIT_AL = """\
+codeunit 50100 "Test Codeunit"
+{
+    procedure DoSomething()
+    begin
+        Message('Hello');
+    end;
+}
+"""
+
+SAMPLE_TABLE_AL = """\
+table 50101 "Test Table"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+    }
+}
+"""
+
+SAMPLE_NEW_CODEUNIT_AL = """\
+codeunit 50102 "Second Codeunit"
+{
+    procedure DoSomethingElse()
+    begin
+        Message('World');
+    end;
+}
+"""
+
+
+@pytest.fixture()
+def al_project() -> Iterator[Path]:
+    """Temp project indexed with the real al_chunker, same settings shape as
+    the production `data/.cocoindex_code/settings.yml` (chunkers: ext al ->
+    al_chunker:al_chunker).
+    """
+    base_dir = Path(tempfile.mkdtemp(prefix="bcatlas_persist_"))
+    project_dir = base_dir / "project"
+    project_dir.mkdir()
+    (project_dir / "Codeunit1.al").write_text(SAMPLE_CODEUNIT_AL)
+    (project_dir / "Table1.al").write_text(SAMPLE_TABLE_AL)
+    (project_dir / ".git").mkdir()
+
+    old_env = os.environ.get("COCOINDEX_CODE_DIR")
+    os.environ["COCOINDEX_CODE_DIR"] = str(base_dir)
+    old_cwd = os.getcwd()
+    os.chdir(project_dir)
+
+    save_user_settings(
+        UserSettings(
+            embedding=EmbeddingSettings(
+                provider="sentence-transformers",
+                model=TEST_EMBEDDING_MODEL,
+            )
+        )
+    )
+    save_project_settings(
+        project_dir,
+        ProjectSettings(
+            include_patterns=["**/*.al"],
+            chunkers=[ChunkerMapping(ext="al", module="al_chunker:al_chunker")],
+        ),
+    )
+
+    try:
+        yield project_dir
+    finally:
+        os.chdir(project_dir)
+        runner.invoke(app, ["reset", "--all", "-f"])
+        stop_daemon()
+        os.chdir(old_cwd)
+        if old_env is None:
+            os.environ.pop("COCOINDEX_CODE_DIR", None)
+        else:
+            os.environ["COCOINDEX_CODE_DIR"] = old_env
+
+
+def _index(project_root: str) -> IndexingProgress:
+    """Run indexing and return the last progress snapshot seen."""
+    last: list[IndexingProgress] = []
+    client.index(project_root, on_progress=last.append)
+    assert last, "daemon never reported any indexing progress"
+    return last[-1]
+
+
+def test_daemon_restart_resumes_instead_of_reprocessing(al_project: Path) -> None:
+    """First index processes both real files. A daemon restart (simulating a
+    routine deploy -- SIGTERM + respawn, `.cocoindex_code/` untouched on
+    disk) followed by a genuinely new third file must show the two original
+    files coming back as unchanged, not reprocessed.
+    """
+    project_root = str(al_project)
+
+    initial = _index(project_root)
+    assert initial.num_errors == 0
+    assert initial.num_adds == 2
+    assert initial.num_unchanged == 0
+
+    # Simulate a routine deploy: kill and respawn the daemon process. This
+    # must NOT touch `.cocoindex_code/` on disk -- exactly what a
+    # `systemctl restart` does in production (see constitution Principle
+    # VIII).
+    result = runner.invoke(app, ["daemon", "restart"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+
+    # A genuinely new file lands after the restart, same as a real deploy
+    # shipping alongside unrelated code/corpus changes.
+    (al_project / "Codeunit2.al").write_text(SAMPLE_NEW_CODEUNIT_AL)
+
+    after_restart = _index(project_root)
+    assert after_restart.num_errors == 0
+    # The core Principle VIII guarantee: the two pre-restart files must be
+    # recognized as unchanged, not reprocessed by the new daemon process.
+    assert after_restart.num_unchanged == 2
+    assert after_restart.num_adds == 1
+    assert after_restart.num_reprocesses == 0
+
+    status = client.project_status(project_root)
+    assert status.total_files == 3

--- a/registry/tests/test_resolver.py
+++ b/registry/tests/test_resolver.py
@@ -56,6 +56,11 @@ def test_resolve_exact_version_string(_mirror):
     # and a real, live CI run picked up the new value independently of any
     # local state -- same expected-drift situation as before, not a
     # resolver bug.
+    #
+    # UPDATE 2026-08-03: changed again, from 88503b3fb425952d8b67a467b70
+    # bc926af4d8f45 to 1ff2c27ddc1358f24f54d34a8f7f9e6429f5c2ad. Confirmed
+    # live via a fresh `git clone --bare` of the real upstream mirror --
+    # same expected-drift situation, caught by a real CI run on PR #15.
     spec = "w1-28.1.49838.51992"
 
     result = resolver.resolve_version(_COUNTRY, spec, mirror_dir=_mirror)
@@ -64,7 +69,7 @@ def test_resolve_exact_version_string(_mirror):
     assert result.resolved is True
     assert result.country == _COUNTRY
     assert result.version_string == spec
-    assert result.commit_sha == "88503b3fb425952d8b67a467b70bc926af4d8f45"
+    assert result.commit_sha == "1ff2c27ddc1358f24f54d34a8f7f9e6429f5c2ad"
 
 
 def test_resolve_exact_commit_sha(_mirror):
@@ -86,10 +91,10 @@ def test_resolve_loose_major_minor_picks_single_highest_build(_mirror):
     assert result.country == _COUNTRY
     # Real highest w1-28.1.* build, confirmed live via
     # `git log --format='%s' | grep '^w1-28\\.1\\.' | sort` against the real
-    # upstream mirror. UPDATE 2026-07-31, then again 2026-08-02: new builds
-    # keep landing upstream -- expected drift (module docstring), not a
-    # code bug.
-    assert result.version_string == "w1-28.1.49838.53220"
+    # upstream mirror. UPDATE 2026-07-31, then again 2026-08-02, then again
+    # 2026-08-03: new builds keep landing upstream -- expected drift
+    # (module docstring), not a code bug.
+    assert result.version_string == "w1-28.1.49838.53249"
     assert result.version_string.startswith("w1-28.1.")
 
 
@@ -159,9 +164,10 @@ def test_list_major_versions_summarizes_by_major_minor(_mirror):
     assert "28.1" in major_minors
     assert "28.2" in major_minors
     entry = next(v for v in versions if v["major_minor"] == "28.1")
-    # UPDATE 2026-07-31, then again 2026-08-02: expected drift, see
-    # test_resolve_loose_major_minor_picks_single_highest_build above.
-    assert entry["latest_build"] == "w1-28.1.49838.53220"
+    # UPDATE 2026-07-31, then again 2026-08-02, then again 2026-08-03:
+    # expected drift, see test_resolve_loose_major_minor_picks_single_highest_build
+    # above.
+    assert entry["latest_build"] == "w1-28.1.49838.53249"
 
 
 def test_list_major_versions_returns_none_for_unknown_country(_mirror):


### PR DESCRIPTION
## Summary
- Verified against the deployed cocoindex-code code (commit 7fe0e89, identical on prod VM and here) that a routine daemon restart resumes from on-disk state instead of reprocessing the whole corpus from scratch — confirmed both by reading `Project.create()`/`resolve_db_dir()` and live on the VM (post-restart `num_unchanged` was already >10,000, not 0).
- Documents this as constitution Principle VIII ("Deploys Must Not Reset the Serving Index") and corrects the now-outdated "fresh daemon can't trust any prior state" claim in CLAUDE.md.
- Adds a new CI job (`search-daemon-persistence`) that exercises the real daemon/CLI machinery with the real `al_chunker` plugin against a tiny synthetic AL project: indexes it, restarts the daemon mid-session, adds a new file, re-indexes, and asserts the pre-restart files come back as `num_unchanged` rather than reprocessed.

## Test plan
- [x] `chunker/tests/test_daemon_persistence.py` run locally via `uv run --project tools/cocoindex-code --with-editable chunker pytest chunker/tests/test_daemon_persistence.py -v` — passes (22s)
- [ ] CI green on this PR
- [ ] Once green, add the new job's context to branch protection's required status checks (follow-up, not part of this PR's diff)

https://claude.ai/code/session_01R7vy16Y6VeWmDXQKSxBMGv