### PR TITLE
Bump tools/graphify-al: fix AL object labels to include type and ID

### DIFF
--- a/registry/tests/test_resolver.py
+++ b/registry/tests/test_resolver.py
@@ -61,6 +61,11 @@ def test_resolve_exact_version_string(_mirror):
     # bc926af4d8f45 to 1ff2c27ddc1358f24f54d34a8f7f9e6429f5c2ad. Confirmed
     # live via a fresh `git clone --bare` of the real upstream mirror --
     # same expected-drift situation, caught by a real CI run on PR #15.
+    #
+    # UPDATE 2026-08-05: changed again, from 1ff2c27ddc1358f24f54d34a8f7f
+    # 9e6429f5c2ad to 5a1047abc2924b31e03fb78ab1e8ec1bfe3eb638. Confirmed
+    # live via a fresh `git clone --bare` of the real upstream mirror --
+    # same expected-drift situation, caught by a real CI run on PR #16.
     spec = "w1-28.1.49838.51992"
 
     result = resolver.resolve_version(_COUNTRY, spec, mirror_dir=_mirror)
@@ -69,7 +74,7 @@ def test_resolve_exact_version_string(_mirror):
     assert result.resolved is True
     assert result.country == _COUNTRY
     assert result.version_string == spec
-    assert result.commit_sha == "1ff2c27ddc1358f24f54d34a8f7f9e6429f5c2ad"
+    assert result.commit_sha == "5a1047abc2924b31e03fb78ab1e8ec1bfe3eb638"
 
 
 def test_resolve_exact_commit_sha(_mirror):
@@ -92,9 +97,9 @@ def test_resolve_loose_major_minor_picks_single_highest_build(_mirror):
     # Real highest w1-28.1.* build, confirmed live via
     # `git log --format='%s' | grep '^w1-28\\.1\\.' | sort` against the real
     # upstream mirror. UPDATE 2026-07-31, then again 2026-08-02, then again
-    # 2026-08-03: new builds keep landing upstream -- expected drift
-    # (module docstring), not a code bug.
-    assert result.version_string == "w1-28.1.49838.53249"
+    # 2026-08-03, then again 2026-08-05: new builds keep landing upstream --
+    # expected drift (module docstring), not a code bug.
+    assert result.version_string == "w1-28.1.49838.53330"
     assert result.version_string.startswith("w1-28.1.")
 
 
@@ -164,10 +169,10 @@ def test_list_major_versions_summarizes_by_major_minor(_mirror):
     assert "28.1" in major_minors
     assert "28.2" in major_minors
     entry = next(v for v in versions if v["major_minor"] == "28.1")
-    # UPDATE 2026-07-31, then again 2026-08-02, then again 2026-08-03:
-    # expected drift, see test_resolve_loose_major_minor_picks_single_highest_build
-    # above.
-    assert entry["latest_build"] == "w1-28.1.49838.53249"
+    # UPDATE 2026-07-31, then again 2026-08-02, then again 2026-08-03, then
+    # again 2026-08-05: expected drift, see
+    # test_resolve_loose_major_minor_picks_single_highest_build above.
+    assert entry["latest_build"] == "w1-28.1.49838.53330"
 
 
 def test_list_major_versions_returns_none_for_unknown_country(_mirror):


### PR DESCRIPTION
## Summary
- AL object node labels now include object type + numeric ID (e.g. `Codeunit 12 "Gen. Jnl.-Post Line"`), not just the bare name — fixes a real, reproduced bug where the canonical AL reference format returned "No node matching found" from `bcatlas_get_object_source`/`get_signature`/`get_procedure_body`/`get_node`/`get_neighbors`.
- Bare-name lookups still work (no regression).
- Same-named objects of different types (e.g. a table and a page both named `"Item"`) are now individually resolvable by full reference, and a bare-name query matching multiple such objects reports the ambiguity instead of silently picking one.
- Submitted upstream as [ChristianHovenbitzer/graphify-al#58](https://github.com/ChristianHovenbitzer/graphify-al/pull/58) (open, not yet merged) — applied here immediately per `specs/004-al-object-labels/spec.md`'s Assumptions, not blocked on upstream review.
- Full spec/plan/tasks in `specs/004-al-object-labels/`.

## Test plan
- [x] `pytest tests/ -k "al_"` — 269 passed on both the upstream PR branch and `bc-code-atlas-fixes`
- [x] Full `tools/graphify-al` suite — 2350 passed, 4 pre-existing/unrelated failures (verified pre-existing on the base commit, not introduced by this change)
- [x] Live end-to-end reproduction of the original bug report's exact query, confirmed fixed
- [ ] Regenerate warm (country, version) graph artifacts on the VM after this deploys (US3, `specs/004-al-object-labels/tasks.md` T018-T020) and confirm zero effect on the separate search/embedding daemon