### PR TITLE
Fix build-side ccc index stall watchdog to recognize CPU-busy as not-stalled

### DIFF
--- a/build/build/incremental.py
+++ b/build/build/incremental.py
@@ -366,6 +366,38 @@ def _index_state_fingerprint(search_dir: Path) -> tuple[int, int]:
     return (total, newest)
 
 
+def _daemon_cpu_ticks(runtime_dir: Path) -> int | None:
+    """Total (utime+stime) CPU jiffies for this build's own isolated `ccc`
+    daemon, read directly from `/proc/<pid>/stat` (Linux-only, matches this
+    project's only deployment target -- no new dependency needed). `None`
+    if `daemon.pid` doesn't exist yet or the `/proc` entry isn't readable
+    (daemon not up yet, or a permission/race hiccup -- best-effort).
+
+    Same fix as `chunker/mcp_http_server.py`'s identically-named function
+    (added there after an earlier live-reproduced instance of this exact
+    false-stall pattern on the search-serving side), ported here after
+    live-reproducing it again on the build side (this session, retrying a
+    genuinely cold build -- no warm sibling to reuse -- for a country never
+    indexed before): the isolated per-build daemon spent its first several
+    minutes loading the embedding model and starting its first large
+    embedding batch, writing nothing under `.cocoindex_code/` the whole
+    time, while `ps`/`/proc` directly confirmed it was burning 200%+ CPU,
+    not idle. The on-disk fingerprint alone can't distinguish that from the
+    real, documented upstream hang (`daemon.py`'s "every thread sleeping,
+    zero CPU accrual" bug, Principle VI, out of reach here) this watchdog
+    exists to catch -- a daemon burning CPU is by definition not that.
+    """
+    try:
+        pid = int((runtime_dir / "daemon.pid").read_text().strip())
+        fields = Path(f"/proc/{pid}/stat").read_text().rsplit(")", 1)[-1].split()
+        # After the last ")" (closes the process name): field 0 is state,
+        # fields 11/12 (0-indexed from there) are utime/stime in clock
+        # ticks (man proc(5)) -- same field math as the chunker-side twin.
+        return int(fields[11]) + int(fields[12])
+    except (OSError, ValueError, IndexError):
+        return None
+
+
 def _kill_daemon_by_pidfile(runtime_dir: Path) -> None:
     """SIGTERM -> SIGKILL the per-build `ccc run-daemon` via its own
     `daemon.pid` file. Deliberately NOT `ccc daemon stop`: its graceful
@@ -520,6 +552,7 @@ def _run_ccc_index(search_dir: Path, init_if_needed: bool) -> None:
                     start_new_session=True,
                 )
             last_fp = attempt_start_fp
+            last_cpu = _daemon_cpu_ticks(runtime_dir)
             last_progress = time.monotonic()
             stalled = False
             while True:
@@ -530,8 +563,10 @@ def _run_ccc_index(search_dir: Path, init_if_needed: bool) -> None:
                     pass
                 now = time.monotonic()
                 fp = _index_state_fingerprint(search_dir)
-                if fp != last_fp:
+                cpu = _daemon_cpu_ticks(runtime_dir)
+                if fp != last_fp or (cpu is not None and cpu != last_cpu):
                     last_fp = fp
+                    last_cpu = cpu
                     last_progress = now
                 elif now - last_progress >= _CCC_STALL_TIMEOUT_S:
                     stalled = True

--- a/build/tests/test_incremental_stall_watchdog.py
+++ b/build/tests/test_incremental_stall_watchdog.py
@@ -1,0 +1,39 @@
+"""Tests for `build.incremental._daemon_cpu_ticks`: the CPU-activity signal
+added to the `ccc index` stall watchdog after live-reproducing a false stall
+on a cold (never-before-built) country's build -- the isolated per-build
+daemon was burning real CPU loading the embedding model and starting its
+first embedding batch, writing nothing under `.cocoindex_code/` for over
+five minutes, which the on-disk-fingerprint-only watchdog misread as the
+real, unrecoverable upstream hang and killed prematurely, forever, since a
+fresh daemon just repeats the same slow startup on every retry.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from build.incremental import _daemon_cpu_ticks
+
+
+def test_missing_pidfile_returns_none(tmp_path: Path) -> None:
+    assert _daemon_cpu_ticks(tmp_path) is None
+
+
+def test_pidfile_pointing_at_nonexistent_pid_returns_none(tmp_path: Path) -> None:
+    (tmp_path / "daemon.pid").write_text("999999999")
+    assert _daemon_cpu_ticks(tmp_path) is None
+
+
+def test_pidfile_with_garbage_content_returns_none(tmp_path: Path) -> None:
+    (tmp_path / "daemon.pid").write_text("not-a-pid")
+    assert _daemon_cpu_ticks(tmp_path) is None
+
+
+def test_pidfile_pointing_at_a_real_process_returns_positive_ticks(tmp_path: Path) -> None:
+    # Our own process is guaranteed to be running and to have accrued some
+    # CPU time just by getting this far -- a real /proc read, not a mock
+    # (constitution Principle V).
+    (tmp_path / "daemon.pid").write_text(str(os.getpid()))
+    ticks = _daemon_cpu_ticks(tmp_path)
+    assert ticks is not None
+    assert ticks >= 0


### PR DESCRIPTION
## Summary

Live incident found while monitoring the VM after PR #22's deploy: the first community build request since publishing this project (`es`, commit `d8853cd3e316da5124904e08129ffed9ba741ebf`) never completed. It hit a false-stall pattern already found and fixed once on the search-serving side (`chunker/mcp_http_server.py`'s `_daemon_cpu_ticks`, see constitution Principle VIII history) but never ported to the build side's own equivalent watchdog in `build/build/incremental.py`.

A cold build (no warm sibling to reuse) spends its first several minutes loading the embedding model and starting its first large embedding batch, writing nothing under `.cocoindex_code/` the whole time. The on-disk-fingerprint-only watchdog reads that as the real, documented upstream daemon hang and kills it — 36+ times over 4+ hours in this case, without indexing ever getting a chance to start.

Confirmed live before writing the fix: retried the same request and watched the isolated build daemon burning 200%+ CPU on `ps`/`/proc` while the watchdog was seconds away from killing it as "stalled."

## Fix

Same approach already proven on the search-serving side: track the build daemon's own CPU ticks (`runtime_dir/daemon.pid` → `/proc/<pid>/stat`) alongside the on-disk fingerprint, and only declare a stall when neither signal has moved for `_CCC_STALL_TIMEOUT_S`. A daemon burning CPU is by definition not the zero-CPU-accrual hang this watchdog exists to catch, so this doesn't weaken detection of the real case — it only stops misclassifying genuine, undetected-on-disk computation as one.

## Test plan

- [x] 4 new unit tests for `_daemon_cpu_ticks` (missing pidfile, dead pid, garbage content, a real process)
- [x] Full `build/tests/` suite passes (31 tests, no regressions)
- [x] Plan: once merged and deployed, retry the live `es` build request and confirm it actually completes this time

https://claude.ai/code/session_019Lq2Pc7n4xxanBJSBW1VPS