### PR TITLE
Force submodule checkout in deploy-vm.sh to prevent stray drift from blocking a deploy

### DIFF
--- a/scripts/deploy-vm.sh
+++ b/scripts/deploy-vm.sh
@@ -27,7 +27,15 @@ main() {
   echo "==> git pull"
   git fetch --quiet origin master
   git reset --hard origin/master
-  git submodule update --init --recursive
+  # --force: a submodule's own uv.lock routinely gets rewritten in place by
+  # `uv sync`/`uv run` below (a benign self-referencing version-stamp drift,
+  # not a real dependency change -- confirmed live, harmless to discard) --
+  # without --force, `git submodule update` refuses to check out the new
+  # pinned commit whenever that drift is present, aborting the whole deploy
+  # under `set -e` before `systemctl restart` ever runs (confirmed live: PR
+  # #28's deploy failed exactly this way, leaving the VM on the prior
+  # commit's code with no restart attempted).
+  git submodule update --init --recursive --force
 
   echo "==> uv sync (all subprojects)"
   for p in tools/cocoindex-code chunker aggregator registry build; do


### PR DESCRIPTION
## Summary

PR #28's deploy to the VM failed: `git submodule update --init --recursive` (in `scripts/deploy-vm.sh`) refused to check out the newly pinned `tools/graphify-al` commit because that submodule's own `uv.lock` had a local modification — the same benign self-referencing version-stamp drift that `uv sync`/`uv run` routinely leaves behind locally (I ran into it repeatedly this session; it's harmless, just the lockfile catching up to the package's own version in `pyproject.toml`).

Under `set -e`, the whole deploy script aborted right there, before `systemctl restart bcatlas.target` ever ran. The VM was left silently on the prior commit's code — not down, just stale — with no restart attempted.

I cleaned up the VM by hand and finished that deploy manually. This PR adds `--force` to the submodule checkout so the same drift can't block a future deploy again.

## Test plan

- [x] `bash -n scripts/deploy-vm.sh` — syntax OK
- [x] Reproduced the exact failure live on the VM, fixed it by hand, confirmed all 5 services came back up on the new commit
- [ ] CI green on this PR (no dedicated test suite covers this VM-only script)
