### PR TITLE
Wire bcatlas_find_by_global_id through the aggregator and raise the default graph size cap

### DIFF
--- a/aggregator/unified_mcp_server.py
+++ b/aggregator/unified_mcp_server.py
@@ -298,7 +298,16 @@ def create_aggregator(search_url: str, graph_url: str, registry_url: str, build_
         depth: int = Field(default=3, description="Traversal depth (1-6)"),
         token_budget: int = Field(default=6000, description="Max output tokens"),
         context_filter: list[str] | None = Field(
-            default=None, description="Optional explicit edge-context filter, e.g. ['call', 'field']"
+            default=None,
+            description=(
+                "Optional explicit edge-context filter, e.g. ['call', 'field']."
+                " Also accepts 'cross_app', a structural filter (not a"
+                " relation kind) that keeps only edges whose two endpoints"
+                " belong to different apps (AL corpora only) -- combine it"
+                " with a relation kind (e.g. ['cross_app', 'call']) to see"
+                " only cross-app calls, or use it alone for every cross-app"
+                " edge regardless of kind."
+            ),
         ),
         country: str | None = Field(
             default=None,
@@ -355,6 +364,43 @@ def create_aggregator(search_url: str, graph_url: str, registry_url: str, build_
         ),
     ) -> Any:
         return await _forward(graph_url, "bcatlas_get_node", {"label": label, "country": country, "version": version})
+
+    @mcp.tool(
+        name="bcatlas_find_by_global_id",
+        description=(
+            "Cross-graph federation lookup: find the node(s) on a graph"
+            " matching a `global_id` value copied from another graph's"
+            " bcatlas_get_node output. `global_id` is a deterministic join"
+            " key stamped on every AL node (real objects and external stubs"
+            " alike), so a stub for object X in one corpus and the real X"
+            " node in its own corpus share the same value -- use this to"
+            " bridge two independently-hosted graphs at query time."
+        ),
+    )
+    async def find_by_global_id(
+        global_id: str = Field(description="global_id value to look up, e.g. from another graph's bcatlas_get_node output"),
+        country: str | None = Field(
+            default=None,
+            description=(
+                "Country code (e.g. 'w1', 'us') for a specific (country,"
+                " version) pair's graph instead of the default. Must be"
+                " paired with `version`."
+            ),
+        ),
+        version: str | None = Field(
+            default=None,
+            description=(
+                "Exact `commit_sha` (NOT `version_string`) from"
+                " bcatlas_resolve_version/bcatlas_request_version, paired"
+                " with `country`."
+            ),
+        ),
+    ) -> Any:
+        return await _forward(
+            graph_url,
+            "bcatlas_find_by_global_id",
+            {"global_id": global_id, "country": country, "version": version},
+        )
 
     @mcp.tool(
         name="bcatlas_get_neighbors",

--- a/scripts/start-graph-server.sh
+++ b/scripts/start-graph-server.sh
@@ -19,6 +19,15 @@ between two BC concepts.
 EOF
 )}"
 
+# graphify-al's own safety cap on graph.json (guards against loading a
+# runaway/corrupt file) defaults to 512MB. The default w1-28 corpus's real
+# graph.json crossed that after the #26/#27 rebuild (~707MB -- global_id/
+# al_owning_app on every AL node, plus ordinary upstream corpus growth since
+# the last rebuild) and the service crash-looped on every restart until this
+# was raised (confirmed live). 1GB leaves real headroom for continued
+# organic growth without disabling the cap outright.
+export GRAPHIFY_MAX_GRAPH_BYTES="${GRAPHIFY_MAX_GRAPH_BYTES:-1GB}"
+
 cd "$ROOT/tools/graphify-al"
 exec uv run --extra al python -m graphify.serve \
     "$ROOT/data/w1-28-src/graphify-out/graph.json" \


### PR DESCRIPTION
## Summary

Two follow-up fixes discovered while verifying #26/#27 (`global_id`/cross-app filtering) live against the real public endpoint.

**Aggregator gap.** The aggregator doesn't dynamically proxy its backends' tool lists — it defines and forwards each tool by hand. `bcatlas_find_by_global_id` was added to the graph backend directly in #28 but never wired into the aggregator, so it worked when I called the graph server directly but returned "Unknown tool" through the public endpoint. I added it here, following the same pattern as `bcatlas_get_node`, and documented the new `cross_app` `context_filter` value on `bcatlas_query_graph`'s description too (that one already worked — it's a plain pass-through parameter — just wasn't documented at this layer).

**Graph size cap.** Rebuilding the default `w1-28` graph after #26/#27 (the new fields on every AL node, plus ordinary upstream corpus growth) pushed `graph.json` to ~707MB, past graphify-al's 512MB safety cap. The graph service crash-looped on every restart until I raised it. I fixed the live VM with a temporary `systemctl set-environment` override; this PR makes it durable by setting `GRAPHIFY_MAX_GRAPH_BYTES=1GB` as the script's own default, so it survives a VM reboot or reprovisioning.

## Test plan

- [x] `python3 -c "import unified_mcp_server"` — imports cleanly
- [x] `bash -n scripts/start-graph-server.sh` — syntax OK
- [x] Confirmed live (before this fix) that the raw graph backend already lists `bcatlas_find_by_global_id` correctly, and that the aggregator specifically was the layer rejecting it as "Unknown tool"
- [ ] CI green on this PR
- [ ] Post-merge: re-verify `bcatlas_find_by_global_id` round-trips through the real public endpoint
