### PR TITLE
Bump tools/graphify-al: fix #33 + resolve_node/red-spec tests

### DIFF
--- a/registry/tests/test_resolver.py
+++ b/registry/tests/test_resolver.py
@@ -71,6 +71,10 @@ def test_resolve_exact_version_string(_mirror):
     # ec1bfe3eb638 to 2a482cf89989c0219d75937232ef828b78a314eb. Confirmed
     # live via a fresh `git clone --bare` of the real upstream mirror --
     # same expected-drift situation, caught by a real CI run on PR #22.
+    #
+    # UPDATE 2026-08-13: changed again, from 2a482cf89989c0219d75937232e
+    # f828b78a314eb to 136774729359fdb059e05db27847e5411d8ae1b8. Same
+    # expected-drift situation, caught by a real CI run on PR #34.
     spec = "w1-28.1.49838.51992"
 
     result = resolver.resolve_version(_COUNTRY, spec, mirror_dir=_mirror)
@@ -79,7 +83,7 @@ def test_resolve_exact_version_string(_mirror):
     assert result.resolved is True
     assert result.country == _COUNTRY
     assert result.version_string == spec
-    assert result.commit_sha == "2a482cf89989c0219d75937232ef828b78a314eb"
+    assert result.commit_sha == "136774729359fdb059e05db27847e5411d8ae1b8"
 
 
 def test_resolve_exact_commit_sha(_mirror):
@@ -102,10 +106,10 @@ def test_resolve_loose_major_minor_picks_single_highest_build(_mirror):
     # Real highest w1-28.1.* build, confirmed live via
     # `git log --format='%s' | grep '^w1-28\\.1\\.' | sort` against the real
     # upstream mirror. UPDATE 2026-07-31, then again 2026-08-02, then again
-    # 2026-08-03, then again 2026-08-05, then again 2026-08-12: new builds
-    # keep landing upstream -- expected drift (module docstring), not a
-    # code bug.
-    assert result.version_string == "w1-28.1.49838.53562"
+    # 2026-08-03, then again 2026-08-05, then again 2026-08-12, then again
+    # 2026-08-13: new builds keep landing upstream -- expected drift
+    # (module docstring), not a code bug.
+    assert result.version_string == "w1-28.1.49838.53582"
     assert result.version_string.startswith("w1-28.1.")
 
 
@@ -176,9 +180,10 @@ def test_list_major_versions_summarizes_by_major_minor(_mirror):
     assert "28.2" in major_minors
     entry = next(v for v in versions if v["major_minor"] == "28.1")
     # UPDATE 2026-07-31, then again 2026-08-02, then again 2026-08-03, then
-    # again 2026-08-05, then again 2026-08-12: expected drift, see
+    # again 2026-08-05, then again 2026-08-12, then again 2026-08-13:
+    # expected drift, see
     # test_resolve_loose_major_minor_picks_single_highest_build above.
-    assert entry["latest_build"] == "w1-28.1.49838.53562"
+    assert entry["latest_build"] == "w1-28.1.49838.53582"
 
 
 def test_list_major_versions_returns_none_for_unknown_country(_mirror):


### PR DESCRIPTION
## Summary
- `tools/graphify-al`#33: member-level external stubs minted for `calls`/`subscribes` into out-of-corpus objects (#31) never carried the target object's type, so `al_object_type` was missing and `global_id` had an empty type segment. Fixed by threading the call/subscribe site's known object type through to the per-member stub.
- Ported `bcatlas_resolve_node` (deterministic object/member lookup) and `get_neighbors` member-label qualification from upstream `al-support`'s `952d414`, adapted to this project's multi-tenant routing and canonical label format.
- Ported upstream's red/TDD spec tests (inert by default) and a standalone `graph_conformance.py` checker.
- Also folded in a branch-history fix: `bc-code-atlas-fixes` previously had no real merge ancestry with upstream `al-support` (a squash-apply from 2026-07-31 masqueraded as a merge commit) -- rebuilt with honest ancestry, content verified byte-for-byte identical before/after.

## Test plan
- [x] `tools/graphify-al` full test suite green (same pre-existing/environmental failures as before: symlink/walk edge cases, falkordb-server-dependent tests, one tool-naming assertion)
- [ ] CI on this PR