### PR TITLE
Wire bcatlas_resolve_node through the aggregator and CLI skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,38 @@ here since they're not principles, just measurements:
   dynamic/runtime discovery, complementary but out of scope for a static
   index. Don't re-evaluate unless the two layers above prove insufficient.
 
+## Checklist: bumping `tools/graphify-al` (new/changed MCP tool)
+
+`tools/graphify-al`'s `graphify/serve.py` is a vendored fork's serving
+layer — it is NOT what clients talk to. `aggregator/unified_mcp_server.py`
+re-declares every tool it forwards by name (`@mcp.tool(name="bcatlas_...")`,
+manual `_forward(...)` call) rather than proxying the backend's tool list
+transparently, and `skills/bc-code-atlas-cli/bc-code-atlas.js` separately
+hardcodes its own `COMMANDS` table (one entry per tool) plus a matching
+`printHelp()` line. **Neither of those is auto-derived from graphify-al's
+tool list — a new or renamed `bcatlas_*` tool added upstream (or in a local
+graphify-al fix) does not reach real clients until both are updated by
+hand.** This bit us for real: `bcatlas_resolve_node` was added to
+graphify-al, bumped into this repo, deployed, and verified live on the VM
+— but was unreachable through the public aggregator and missing from the
+shipped CLI skill until caught by a follow-up question, not by any
+automated check.
+
+Whenever you bump the `tools/graphify-al` submodule pointer (or otherwise
+change its MCP tool surface) and before opening/merging that PR:
+
+1. Diff the tool names: `grep -n 'name="bcatlas_' tools/graphify-al/graphify/serve.py`
+   vs. `grep -n 'name="bcatlas_' aggregator/unified_mcp_server.py` — every
+   graph-backend tool name must appear in both, and any renamed/removed
+   tool must be updated/removed in the aggregator too (not just added).
+2. Update `skills/bc-code-atlas-cli/bc-code-atlas.js`'s `COMMANDS` table
+   and `printHelp()` text, and `skills/bc-code-atlas-cli/SKILL.md`'s tool
+   list and tool-count callout, to match.
+3. There is currently no automated test enforcing this parity (the CI
+   "smoke-import" job only checks the aggregator imports, not that its
+   tool list is complete) — until one exists, this is a manual step, not
+   optional because CI stayed green.
+
 ## Non-goals (current)
 
 - Don't try to fix or extend `graphify-al`'s partial call-resolution

--- a/aggregator/unified_mcp_server.py
+++ b/aggregator/unified_mcp_server.py
@@ -92,13 +92,17 @@ _AGGREGATOR_INSTRUCTIONS = (
     " object/procedure name, skip straight to step 3 instead -- it's exact"
     " and cheaper than searching for something you can already name."
     "\n"
-    "2. `bcatlas_query_graph`, `bcatlas_get_node`, `bcatlas_get_neighbors`, `bcatlas_get_community`,"
+    "2. `bcatlas_query_graph`, `bcatlas_get_node`, `bcatlas_resolve_node`,"
+    " `bcatlas_get_neighbors`, `bcatlas_get_community`,"
     " `bcatlas_god_nodes`, `bcatlas_graph_stats`, `bcatlas_shortest_path` -- the exact structural"
     " relationship graph (objects, procedures, event subscriptions,"
     " extension targets) with real call/subscribe/extend edges extracted"
     " from source. Use these once you have a concrete node to trace: what"
     " calls or subscribes to it, what it extends, or how two BC concepts"
-    " connect."
+    " connect. Prefer `bcatlas_resolve_node` over `bcatlas_get_node` whenever"
+    " you already know the object type -- `bcatlas_get_node` is a fuzzy label"
+    " match and can return a same-named page control instead of the table"
+    " field you meant."
     "\n"
     "3. `bcatlas_get_signature`, `bcatlas_get_procedure_body`, `bcatlas_get_object_source` -- exact"
     " source text re-read from the real source files for a node the previous"
@@ -364,6 +368,58 @@ def create_aggregator(search_url: str, graph_url: str, registry_url: str, build_
         ),
     ) -> Any:
         return await _forward(graph_url, "bcatlas_get_node", {"label": label, "country": country, "version": version})
+
+    @mcp.tool(
+        name="bcatlas_resolve_node",
+        description=(
+            "Deterministically resolve a BC object/procedure to its canonical"
+            " node ID. Pass the object type (table, page, codeunit, report,"
+            " enum, tableextension, ...), the object name, and optionally a"
+            " member (field, procedure or trigger name). Returns the matching"
+            " node IDs with source anchors -- feed an ID into"
+            " bcatlas_get_neighbors to traverse. PREFER this over"
+            " bcatlas_get_node whenever you know what kind of thing you are"
+            " looking for (bcatlas_get_node is fuzzy and may return a"
+            " similarly named page control instead of the table)."
+        ),
+    )
+    async def resolve_node(
+        object_type: str = Field(description="AL object type, e.g. 'table', 'page', 'codeunit'"),
+        object_name: str = Field(description="Object name, e.g. 'VAT Posting Setup'"),
+        member: str | None = Field(
+            default=None,
+            description="Optional field/procedure/trigger name, e.g. 'VAT Calculation Type' or 'FailIfVATPostingSetupHasVATEntries'",
+        ),
+        limit: int = Field(default=10, description="Max results"),
+        country: str | None = Field(
+            default=None,
+            description=(
+                "Country code (e.g. 'w1', 'us') for a specific (country,"
+                " version) pair's graph instead of the default. Must be"
+                " paired with `version`."
+            ),
+        ),
+        version: str | None = Field(
+            default=None,
+            description=(
+                "Exact `commit_sha` (NOT `version_string`) from"
+                " bcatlas_resolve_version/bcatlas_request_version, paired"
+                " with `country`."
+            ),
+        ),
+    ) -> Any:
+        return await _forward(
+            graph_url,
+            "bcatlas_resolve_node",
+            {
+                "object_type": object_type,
+                "object_name": object_name,
+                "member": member,
+                "limit": limit,
+                "country": country,
+                "version": version,
+            },
+        )
 
     @mcp.tool(
         name="bcatlas_find_by_global_id",

--- a/skills/bc-code-atlas-cli/SKILL.md
+++ b/skills/bc-code-atlas-cli/SKILL.md
@@ -27,7 +27,7 @@ single script.
 node <skill-dir>/bc-code-atlas.js <command> [args...] [--flag value] [--json]
 ```
 
-Run with `--help` for the full command list. All 17 upstream `bcatlas_*` tools are
+Run with `--help` for the full command list. All 18 upstream `bcatlas_*` tools are
 covered, one subcommand each (dashes instead of underscores, `bcatlas_` prefix
 dropped):
 
@@ -37,7 +37,7 @@ dropped):
 
 **Structural graph**
 - `query-graph <question> [--mode bfs|dfs] [--depth N]` — broad BFS/DFS graph search
-- `get-node <label>` / `get-neighbors <label> [--relation-filter R]`
+- `get-node <label>` / `resolve-node <object_type> <object_name> [--member M]` (deterministic — prefer this over `get-node` when you know the object type) / `get-neighbors <label> [--relation-filter R]`
 - `get-community <community_id>` / `god-nodes [--top-n N]` / `graph-stats` / `shortest-path <source> <target>`
 
 **Multi-version/country registry & build**

--- a/skills/bc-code-atlas-cli/bc-code-atlas.js
+++ b/skills/bc-code-atlas-cli/bc-code-atlas.js
@@ -98,6 +98,11 @@ const COMMANDS = {
     optional: ['mode', 'depth', 'token_budget', 'context_filter', 'country', 'version'],
   },
   'get-node': { tool: 'bcatlas_get_node', positional: ['label'], optional: ['country', 'version'] },
+  'resolve-node': {
+    tool: 'bcatlas_resolve_node',
+    positional: ['object_type', 'object_name'],
+    optional: ['member', 'limit', 'country', 'version'],
+  },
   'get-neighbors': {
     tool: 'bcatlas_get_neighbors',
     positional: ['label'],
@@ -178,6 +183,7 @@ Commands:
   search <query> [--limit N] [--offset N] [--include-tests true] [--country C] [--version SHA]
   query-graph <question> [--mode bfs|dfs] [--depth N] [--country C] [--version SHA]
   get-node <label> [--country C] [--version SHA]
+  resolve-node <object_type> <object_name> [--member M] [--limit N] [--country C] [--version SHA]
   get-neighbors <label> [--relation-filter R] [--country C] [--version SHA]
   get-signature <label> [--country C] [--version SHA]
   get-procedure-body <label> [--country C] [--version SHA]


### PR DESCRIPTION
## Summary
- `bcatlas_resolve_node` (added to graphify-al, merged via PR #34) was live and tested on the graphify-al side but unreachable through the public aggregator -- `aggregator/unified_mcp_server.py` re-declares each tool it forwards by name rather than proxying the backend's tool list, so a new backend tool doesn't reach real clients until wired here by hand.
- Adds the tool to the aggregator (matching the `bcatlas_get_node` pattern) and to the `bc-code-atlas-cli` skill's `COMMANDS` table/help text/SKILL.md.
- Adds a checklist to CLAUDE.md for future `tools/graphify-al` bumps so this doesn't slip through silently again -- there's no automated parity check yet.

## Test plan
- [x] `node -c bc-code-atlas.js` / `python3 -c ast.parse(...)` on the aggregator -- both syntactically valid
- [x] CLI `--help` output shows the new `resolve-node` subcommand
- [ ] CI on this PR