### PR TITLE
Fix drifted registry resolver test expectations

### DIFF
--- a/registry/tests/test_resolver.py
+++ b/registry/tests/test_resolver.py
@@ -75,6 +75,10 @@ def test_resolve_exact_version_string(_mirror):
     # UPDATE 2026-08-13: changed again, from 2a482cf89989c0219d75937232e
     # f828b78a314eb to 136774729359fdb059e05db27847e5411d8ae1b8. Same
     # expected-drift situation, caught by a real CI run on PR #34.
+    #
+    # UPDATE 2026-08-19: changed again, from 136774729359fdb059e05db27847
+    # e5411d8ae1b8 to 88c5353d392ec7d2d682a6fd2a73f74d9028289a. Same
+    # expected-drift situation, caught by a real CI run on PR #54.
     spec = "w1-28.1.49838.51992"
 
     result = resolver.resolve_version(_COUNTRY, spec, mirror_dir=_mirror)
@@ -83,7 +87,7 @@ def test_resolve_exact_version_string(_mirror):
     assert result.resolved is True
     assert result.country == _COUNTRY
     assert result.version_string == spec
-    assert result.commit_sha == "136774729359fdb059e05db27847e5411d8ae1b8"
+    assert result.commit_sha == "88c5353d392ec7d2d682a6fd2a73f74d9028289a"
 
 
 def test_resolve_exact_commit_sha(_mirror):
@@ -107,9 +111,9 @@ def test_resolve_loose_major_minor_picks_single_highest_build(_mirror):
     # `git log --format='%s' | grep '^w1-28\\.1\\.' | sort` against the real
     # upstream mirror. UPDATE 2026-07-31, then again 2026-08-02, then again
     # 2026-08-03, then again 2026-08-05, then again 2026-08-12, then again
-    # 2026-08-13: new builds keep landing upstream -- expected drift
-    # (module docstring), not a code bug.
-    assert result.version_string == "w1-28.1.49838.53582"
+    # 2026-08-13, then again 2026-08-19: new builds keep landing upstream --
+    # expected drift (module docstring), not a code bug.
+    assert result.version_string == "w1-28.1.49838.53731"
     assert result.version_string.startswith("w1-28.1.")
 
 
@@ -180,10 +184,10 @@ def test_list_major_versions_summarizes_by_major_minor(_mirror):
     assert "28.2" in major_minors
     entry = next(v for v in versions if v["major_minor"] == "28.1")
     # UPDATE 2026-07-31, then again 2026-08-02, then again 2026-08-03, then
-    # again 2026-08-05, then again 2026-08-12, then again 2026-08-13:
-    # expected drift, see
+    # again 2026-08-05, then again 2026-08-12, then again 2026-08-13, then
+    # again 2026-08-19: expected drift, see
     # test_resolve_loose_major_minor_picks_single_highest_build above.
-    assert entry["latest_build"] == "w1-28.1.49838.53582"
+    assert entry["latest_build"] == "w1-28.1.49838.53731"
 
 
 def test_list_major_versions_returns_none_for_unknown_country(_mirror):


### PR DESCRIPTION
## Summary
- Real w1-28.1.* builds keep landing on the live upstream mirror, which the registry resolver tests assert against with hardcoded exact values (by design — real network-dependent tests, not mocks, per constitution Principle V).
- Same recurring drift already documented in-file from PRs #15, #16, #22, #34. This CI run caught it again, blocking the pending submodule-bump PRs (#54, #55, #47).
- Refreshed the three stale assertions to the values a real CI run on PR #54 just confirmed live.

## Test plan
- [x] CI's `test (registry)` job re-runs against the real live upstream mirror and passes with the updated values.