### PR TITLE
Throttle bcatlas_search's per-query index refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,3 +163,10 @@ jobs:
         run: |
           uv run --project tools/cocoindex-code --with-editable chunker \
             pytest chunker/tests/test_watch_mode.py -v
+
+      # Same job/venv again -- covers the refresh_index throttle that caps
+      # how often bcatlas_search's default incremental corpus scan re-runs.
+      - name: Run index-refresh throttle tests
+        run: |
+          uv run --project tools/cocoindex-code --with-editable chunker \
+            pytest chunker/tests/test_index_refresh_throttle.py -v

--- a/chunker/mcp_http_server.py
+++ b/chunker/mcp_http_server.py
@@ -103,6 +103,48 @@ _OVERFETCH_MULTIPLIER = 4
 _MAX_OVERFETCH_ROUNDS = 3
 _MAX_FETCH_LIMIT = 100
 
+# How often `refresh_index=True` (the search tool's default) actually runs
+# the daemon's full incremental corpus scan, instead of trusting the last
+# scan is still fresh enough. Measured live (2026-09-07) at ~33s of a ~42s
+# total request -- content-hashing every file across w1-28-src + docs +
+# docs-devitpro isn't free even when every file is unchanged. The hosted
+# default corpus has no other freshness mechanism (a deploy only restarts
+# the service, which reopens existing on-disk state rather than reindexing
+# -- Principle VIII; watch mode is opt-in and unset there), so this can't
+# just become `refresh_index=False` outright -- but bump PRs land on the
+# order of hours to days apart (specs/008-reindex-webhook), so a few
+# minutes of extra staleness costs nothing in practice while saving this
+# cost on every query but the first in that window.
+_INDEX_REFRESH_MIN_INTERVAL_S = 300.0
+
+_index_refresh_lock = threading.Lock()
+_last_index_refresh_at = 0.0
+
+
+def _claim_index_refresh() -> bool:
+    """True (and claims it) iff a refresh is due; False if one already ran
+    within `_INDEX_REFRESH_MIN_INTERVAL_S`. Claims before the caller's scan
+    actually runs so two concurrent requests can't both decide to refresh
+    at the same boundary.
+    """
+    global _last_index_refresh_at
+    with _index_refresh_lock:
+        now = time.monotonic()
+        if now - _last_index_refresh_at < _INDEX_REFRESH_MIN_INTERVAL_S:
+            return False
+        _last_index_refresh_at = now
+        return True
+
+
+def _mark_index_refreshed() -> None:
+    """Record that a refresh just ran outside `_claim_index_refresh` (the
+    watch loop's own scan), so a query landing right after doesn't pay for
+    a redundant one.
+    """
+    global _last_index_refresh_at
+    with _index_refresh_lock:
+        _last_index_refresh_at = time.monotonic()
+
 
 def _is_test_path(file_path: str) -> bool:
     return any(_TEST_PATH_SEGMENT.search(seg) for seg in file_path.split("/")[:-1])
@@ -672,8 +714,9 @@ def create_filtered_mcp_server(project_root: str) -> FastMCP:
             default=True,
             description=(
                 "Whether to incrementally update the index before searching."
-                " Set to False for faster consecutive queries"
-                " when the codebase hasn't changed."
+                " Already throttled to at most once every few minutes, so"
+                " back-to-back calls don't repay this cost -- set to False"
+                " to skip it on this call regardless."
             ),
         ),
         languages: list[str] | None = Field(
@@ -760,7 +803,7 @@ def create_filtered_mcp_server(project_root: str) -> FastMCP:
             if paths and target_root == project_root and _corpus_path_prefixes:
                 effective_paths = _expand_paths_for_corpus_prefixes(paths, _corpus_path_prefixes)
 
-            if refresh_index:
+            if refresh_index and _claim_index_refresh():
                 await loop.run_in_executor(
                     None,
                     lambda: _run_with_stall_recovery(
@@ -884,6 +927,7 @@ def _watch_reindex_once(project_root: str) -> None:
     from cocoindex_code import client as _client
 
     _run_with_stall_recovery(lambda: _client.index(project_root), project_root)
+    _mark_index_refreshed()
 
 
 async def _watch_loop(

--- a/chunker/mcp_http_server.py
+++ b/chunker/mcp_http_server.py
@@ -118,7 +118,13 @@ _MAX_FETCH_LIMIT = 100
 _INDEX_REFRESH_MIN_INTERVAL_S = 300.0
 
 _index_refresh_lock = threading.Lock()
-_last_index_refresh_at = 0.0
+_last_index_refresh_at = float("-inf")  # unset -- always due on process start,
+# regardless of the platform's monotonic-clock origin. `time.monotonic()` is
+# CLOCK_MONOTONIC (time since boot on Linux), not since the epoch, so a
+# fresh CI container or VM can report well under
+# `_INDEX_REFRESH_MIN_INTERVAL_S` for its own uptime -- `0.0` looked like a
+# recent refresh there and wrongly skipped the first one (caught live by
+# this file's own CI job on this PR, not reasoned about).
 
 
 def _claim_index_refresh() -> bool:

--- a/chunker/tests/test_index_refresh_throttle.py
+++ b/chunker/tests/test_index_refresh_throttle.py
@@ -20,7 +20,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import mcp_http_server as server  # noqa: E402
 
 
-def _reset(monkeypatch, *, min_interval: float = 300.0, last_refresh: float = 0.0) -> None:
+def _reset(
+    monkeypatch, *, min_interval: float = 300.0, last_refresh: float = float("-inf")
+) -> None:
     monkeypatch.setattr(server, "_INDEX_REFRESH_MIN_INTERVAL_S", min_interval)
     monkeypatch.setattr(server, "_last_index_refresh_at", last_refresh)
 

--- a/chunker/tests/test_index_refresh_throttle.py
+++ b/chunker/tests/test_index_refresh_throttle.py
@@ -1,0 +1,51 @@
+"""Unit tests for the `bcatlas_search` refresh-index throttle.
+
+`refresh_index=True` (the search tool's default) used to re-run the
+daemon's full incremental corpus scan on every single call -- measured live
+(2026-09-07) at ~33s of a ~42s request even when nothing had changed, since
+content-hashing every file across w1-28-src + docs + docs-devitpro isn't
+free just because the result is `num_unchanged`. `_claim_index_refresh`
+caps how often that scan actually runs; these tests cover its own
+check-and-claim logic in isolation, not the real daemon scan (already
+covered by test_daemon_persistence.py).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import mcp_http_server as server  # noqa: E402
+
+
+def _reset(monkeypatch, *, min_interval: float = 300.0, last_refresh: float = 0.0) -> None:
+    monkeypatch.setattr(server, "_INDEX_REFRESH_MIN_INTERVAL_S", min_interval)
+    monkeypatch.setattr(server, "_last_index_refresh_at", last_refresh)
+
+
+def test_first_call_is_due(monkeypatch) -> None:
+    _reset(monkeypatch)
+    assert server._claim_index_refresh() is True
+
+
+def test_second_call_within_window_is_not_due(monkeypatch) -> None:
+    _reset(monkeypatch)
+    assert server._claim_index_refresh() is True
+    assert server._claim_index_refresh() is False
+
+
+def test_call_after_window_elapses_is_due_again(monkeypatch) -> None:
+    import time
+
+    _reset(monkeypatch, min_interval=0.01)
+    assert server._claim_index_refresh() is True
+    time.sleep(0.02)
+    assert server._claim_index_refresh() is True
+
+
+def test_mark_index_refreshed_starts_a_new_window(monkeypatch) -> None:
+    _reset(monkeypatch)
+    server._mark_index_refreshed()
+    assert server._claim_index_refresh() is False

--- a/registry/tests/test_resolver.py
+++ b/registry/tests/test_resolver.py
@@ -79,6 +79,10 @@ def test_resolve_exact_version_string(_mirror):
     # UPDATE 2026-08-19: changed again, from 136774729359fdb059e05db27847
     # e5411d8ae1b8 to 88c5353d392ec7d2d682a6fd2a73f74d9028289a. Same
     # expected-drift situation, caught by a real CI run on PR #54.
+    #
+    # UPDATE 2026-09-07: changed again, from 88c5353d392ec7d2d682a6fd2a73
+    # f74d9028289a to 42ac68bfb71ee011d59b10e51b0c998d9f140901. Same
+    # expected-drift situation, caught by a real CI run on PR #90.
     spec = "w1-28.1.49838.51992"
 
     result = resolver.resolve_version(_COUNTRY, spec, mirror_dir=_mirror)
@@ -87,7 +91,7 @@ def test_resolve_exact_version_string(_mirror):
     assert result.resolved is True
     assert result.country == _COUNTRY
     assert result.version_string == spec
-    assert result.commit_sha == "88c5353d392ec7d2d682a6fd2a73f74d9028289a"
+    assert result.commit_sha == "42ac68bfb71ee011d59b10e51b0c998d9f140901"
 
 
 def test_resolve_exact_commit_sha(_mirror):
@@ -111,9 +115,10 @@ def test_resolve_loose_major_minor_picks_single_highest_build(_mirror):
     # `git log --format='%s' | grep '^w1-28\\.1\\.' | sort` against the real
     # upstream mirror. UPDATE 2026-07-31, then again 2026-08-02, then again
     # 2026-08-03, then again 2026-08-05, then again 2026-08-12, then again
-    # 2026-08-13, then again 2026-08-19: new builds keep landing upstream --
-    # expected drift (module docstring), not a code bug.
-    assert result.version_string == "w1-28.1.49838.53731"
+    # 2026-08-13, then again 2026-08-19, then again 2026-09-07 (PR #90):
+    # new builds keep landing upstream -- expected drift (module
+    # docstring), not a code bug.
+    assert result.version_string == "w1-28.1.49838.54169"
     assert result.version_string.startswith("w1-28.1.")
 
 
@@ -185,9 +190,9 @@ def test_list_major_versions_summarizes_by_major_minor(_mirror):
     entry = next(v for v in versions if v["major_minor"] == "28.1")
     # UPDATE 2026-07-31, then again 2026-08-02, then again 2026-08-03, then
     # again 2026-08-05, then again 2026-08-12, then again 2026-08-13, then
-    # again 2026-08-19: expected drift, see
+    # again 2026-08-19, then again 2026-09-07 (PR #90): expected drift, see
     # test_resolve_loose_major_minor_picks_single_highest_build above.
-    assert entry["latest_build"] == "w1-28.1.49838.53731"
+    assert entry["latest_build"] == "w1-28.1.49838.54169"
 
 
 def test_list_major_versions_returns_none_for_unknown_country(_mirror):


### PR DESCRIPTION
## Summary

`bcatlas_search`'s `refresh_index=True` default runs a full incremental corpus scan before every search call, even when nothing changed. I measured this live on the hosted VM: ~33s of a ~42s request was that scan re-hashing every file across `w1-28-src`, `docs`, and `docs-devitpro`. This throttles it to run at most once every 5 minutes; a request inside that window skips straight to the search.

Five minutes of extra staleness costs nothing in practice: the deploy script only restarts the service (it reopens existing on-disk state, it doesn't reindex), and the reindex-webhook automation only opens bump PRs that a person still merges — those land hours to days apart, not seconds.

## Test plan

- [x] Added `chunker/tests/test_index_refresh_throttle.py` (4 tests) covering the throttle's check/claim/reset logic in isolation
- [x] Added the new test file to `.github/workflows/ci.yml`
- [x] Ran the full `chunker/tests/` suite locally (27 tests, all passing)
- [x] Verified live on the hosted VM before this change: `refresh_index` default took 42s, `refresh_index: false` took 9s for the same query

https://claude.ai/code/session_014wW9ne7wxzP3Csq4AYoTWm